### PR TITLE
Fix GoPay step visibility to hide steps 06 and 13

### DIFF
--- a/webui/frontend/src/components/steps/Step06_GoPay.vue
+++ b/webui/frontend/src/components/steps/Step06_GoPay.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="step-fade-in">
-    <div class="term-divider" data-tail="──────────">步骤 06: GoPay 账号</div>
+    <div class="term-divider" data-tail="──────────">步骤 07: GoPay 账号</div>
     <h2 class="step-h">$&nbsp;GoPay (印尼 e-wallet)<span class="term-cursor"></span></h2>
     <p class="step-sub">每个 ChatGPT Plus 订阅消耗 1 次 WhatsApp OTP + 2 次 PIN 输入。Lite 账号 (无印尼 KYC) 月限额约 IDR 2M ≈ 5-6 单。</p>
 

--- a/webui/frontend/src/stores/wizard.ts
+++ b/webui/frontend/src/stores/wizard.ts
@@ -48,8 +48,8 @@ export const useWizardStore = defineStore("wizard", {
     isStepHidden(n: number): boolean {
       const pm = (this.answers.payment as any)?.method ?? "both";
       if (pm === "gopay") {
-        // Step 6 复用为 GoPay 配置；7(card) / 13(stripe runtime) 都不走
-        if (n === 7) return true;
+        // GoPay 走 step 7；step 6(PayPal) / step 13(stripe runtime) 不走
+        if (n === 6) return true;
         if (n === 13) return true;
         return false;
       }

--- a/webui/frontend/src/views/Wizard.vue
+++ b/webui/frontend/src/views/Wizard.vue
@@ -78,8 +78,8 @@ const STEPS = [Step01, Step02, Step03, Step04, Step05, Step06, Step07, Step08, S
 const store = useWizardStore();
 const router = useRouter();
 const currentStepComponent = computed(() => {
-  // Step 6 = payment-specific config: PayPal / GoPay 同位
-  if (store.currentStep === 6) {
+  // GoPay uses step 7 slot when selected.
+  if (store.currentStep === 7) {
     const pm = (store.answers.payment as any)?.method;
     if (pm === "gopay") return Step06GoPay;
   }


### PR DESCRIPTION
## 1. 改动类型
- [x] 🐛 Bug fix

## 2. 改动摘要
调整 WebUI 向导中 GoPay 的步骤灰显逻辑：GoPay 模式下隐藏 step 06 和 step 13，并保证步骤槽位映射与展示一致。

## 3. 详细说明 + 设计决策
原逻辑下 GoPay 的隐藏步位与预期不一致，导致 stepper 灰显与当前配置步骤出现错位。此次修复保持改动范围在前端向导层：
1) 在 wizard store 中修正 GoPay 的 hidden 规则；
2) 在 Wizard 视图中把 GoPay 组件映射到对应可见步骤槽位；
3) 调整 GoPay 步骤标题文案以匹配槽位。
该方案不触及支付执行链路，仅修复向导可见性与交互一致性。

## 4. 跑通证据
### 复现/验证命令
`cd webui/frontend && pnpm test`
`cd webui/frontend && WEBUI_BASE=/ pnpm build`

### 结果
- `pnpm test`: 12 passed
- `WEBUI_BASE=/ pnpm build`: success

> 截图与修复前/后 UI 对比由提交人补充到 PR 评论。

<img width="3024" height="1716" alt="image" src="https://github.com/user-attachments/assets/8a366877-9a45-42f0-ab98-25351fe67752" />

## 5. Reviewer 本地验证
1. checkout 本分支
2. `cd webui/frontend && pnpm i`
3. `pnpm test`
4. `WEBUI_BASE=/ pnpm build`
5. 回仓库根目录执行 `python3 -m webui.server`
6. 打开 `http://127.0.0.1:8765`，在 step 1 切换支付方式为 GoPay，确认 step 06/13 灰显

## 6. 风险与边界
- 改动仅在 WebUI 步骤可见性层，不影响后端支付流程
- 未覆盖与历史持久化状态冲突的所有异常手工路径（请 reviewer 按本地状态复验）

## 7. 脱敏与合规
- [x] 未提交真实凭证/PII
- [x] 已自查变更文件
