### PR TITLE
Support macOS/Linux pipeline startup without mandatory xvfb-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ python -m venv ~/.venvs/ctfml
 
 完整依赖清单和系统包看 [`docs/installation.md`](docs/installation.md)。
 
+macOS 直接用 `python ...` 跑；Linux 无桌面环境时再在前面加 `xvfb-run -a`。
+
 ### 配
 
 复制模板，填值：
@@ -118,11 +120,14 @@ cp CTF-reg/config.paypal-proxy.example.json   CTF-reg/config.paypal-proxy.json
 ### 跑
 
 ```bash
-# 单次完整流程
+# macOS / 有桌面的 Linux
+python pipeline.py --config CTF-pay/config.paypal.json --paypal
+
+# Linux 无桌面环境
 xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal
 
-# 持续维护补号池
-xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal --daemon
+# 持续维护补号池（Linux 无桌面时同样可在前面加 xvfb-run -a）
+python pipeline.py --config CTF-pay/config.paypal.json --paypal --daemon
 ```
 
 四种运行模式（单次 / 批量 / self-dealer / daemon）的差异和参数看 [`docs/operating-modes.md`](docs/operating-modes.md)。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,12 +4,12 @@
 
 ## 系统要求
 
-- **OS**：Linux（Ubuntu 22.04+ / Debian 11+ / Kali / 任何 systemd 发行版）
+- **OS**：macOS，或 Linux（Ubuntu 22.04+ / Debian 11+ / Kali / 任何 systemd 发行版）
 - **Python**：3.11+
 - **内存**：至少 2 GB（hCaptcha solver + Camoufox 同时跑）
 - **磁盘**：核心约 500 MB，加上 ML venv 总共 5 GB
 - **网络**：能访问 OpenAI / Stripe / PayPal / Cloudflare API
-- **可选**：xvfb（跑无头时用）、gost（带 auth 的 socks5 用）
+- **可选**：xvfb（仅 Linux 无桌面环境时用）、gost（带 auth 的 socks5 用）
 
 ---
 
@@ -28,6 +28,8 @@ sudo curl -sSfL \
     https://github.com/go-gost/gost/releases/latest/download/gost-linux-amd64 \
     -o /usr/local/bin/gost && sudo chmod +x /usr/local/bin/gost
 ```
+
+macOS 不需要安装 xvfb；直接用系统图形环境跑 `python pipeline.py ...` 即可。
 
 ---
 
@@ -103,6 +105,10 @@ cp CTF-reg/config.example.json              CTF-reg/config.noproxy.json
 第一次跑会弹 Camoufox 让你登 PayPal。这一步**必须人肉过一次** OTP 2FA：
 
 ```bash
+# macOS / 有桌面的 Linux
+python pipeline.py --config CTF-pay/config.paypal.json --paypal
+
+# Linux 无桌面环境
 xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal
 ```
 

--- a/webui/backend/preflight/system.py
+++ b/webui/backend/preflight/system.py
@@ -1,6 +1,7 @@
 import shutil
 import sys
 from ._common import CheckResult, PreflightResult, aggregate
+from .. import runtime_env
 
 
 def check() -> PreflightResult:
@@ -15,13 +16,19 @@ def check() -> PreflightResult:
                                   message=f"Python {sys.version.split()[0]} < 3.10"))
 
     # Binaries
-    for binary in ("camoufox", "xvfb-run"):
-        path = shutil.which(binary)
-        checks.append(CheckResult(
-            name=binary,
-            status="ok" if path else "fail",
-            message=path or f"{binary} not found in PATH",
-        ))
+    camoufox_path = shutil.which("camoufox")
+    checks.append(CheckResult(
+        name="camoufox",
+        status="ok" if camoufox_path else "fail",
+        message=camoufox_path or "camoufox not found in PATH",
+    ))
+
+    xvfb_status, xvfb_message = runtime_env.xvfb_check()
+    checks.append(CheckResult(
+        name="xvfb-run",
+        status=xvfb_status,
+        message=xvfb_message,
+    ))
 
     # Playwright import
     try:

--- a/webui/backend/runner.py
+++ b/webui/backend/runner.py
@@ -1,7 +1,8 @@
 """单 active-run 的 pipeline 进程控制器。
 
-封装 `xvfb-run -a python pipeline.py [args]` 子进程：spawn / 流式收 stdout
-到环形日志缓冲 / SIGTERM-优先 stop / 暴露 status + log 给路由层。
+封装 `python pipeline.py [args]` 子进程；Linux 且安装了 xvfb-run 时自动
+加上 `xvfb-run -a` 前缀：spawn / 流式收 stdout 到环形日志缓冲 /
+SIGTERM-优先 stop / 暴露 status + log 给路由层。
 
 GoPay 模式下额外支持 OTP 中转：默认通过 WebUI 内部 HTTP endpoint
 把 WhatsApp / 手动补录 OTP 写入 SQLite，gopay.py 轮询该 endpoint。
@@ -17,6 +18,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from . import runtime_env
 from . import settings as s
 from . import wa_relay
 
@@ -73,7 +75,7 @@ def build_cmd(mode: str, paypal: bool, batch: int, workers: int, self_dealer: in
               register_only: bool, pay_only: bool, gopay: bool = False,
               gopay_otp_file: str = "", count: int = 0) -> list[str]:
     """根据参数拼出最终命令行。"""
-    cmd = ["xvfb-run", "-a", "python", "-u", "pipeline.py",
+    cmd = [*runtime_env.pipeline_cmd_prefix(), "python", "-u", "pipeline.py",
            "--config", str(s.PAY_CONFIG_PATH)]
     # free_only 两个子模式不需要 paypal / gopay 支付段
     if mode in ("free_register", "free_backfill_rt"):

--- a/webui/backend/runtime_env.py
+++ b/webui/backend/runtime_env.py
@@ -1,0 +1,33 @@
+import os
+import shutil
+import sys
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+def is_linux() -> bool:
+    return sys.platform.startswith("linux")
+
+
+def has_display(env: dict[str, str] | None = None) -> bool:
+    env = env or os.environ
+    return bool(str(env.get("DISPLAY") or "").strip() or str(env.get("WAYLAND_DISPLAY") or "").strip())
+
+
+def pipeline_cmd_prefix() -> list[str]:
+    if is_linux() and shutil.which("xvfb-run"):
+        return ["xvfb-run", "-a"]
+    return []
+
+
+def xvfb_check() -> tuple[str, str]:
+    path = shutil.which("xvfb-run")
+    if path:
+        return "ok", path
+    if is_macos():
+        return "ok", "macOS 不需要 xvfb-run；将直接启动 python"
+    if is_linux() and has_display():
+        return "ok", "未安装 xvfb-run；检测到 DISPLAY/WAYLAND_DISPLAY，将直接使用当前桌面会话"
+    return "warn", "xvfb-run not found in PATH；将直接启动 python，Linux 无桌面时建议安装 xvfb"

--- a/webui/frontend/src/components/steps/Step02_System.vue
+++ b/webui/frontend/src/components/steps/Step02_System.vue
@@ -2,7 +2,7 @@
   <section class="step-fade-in">
     <div class="term-divider" data-tail="──────────">步骤 02: 系统</div>
     <h2 class="step-h">$&nbsp;系统依赖体检<span class="term-cursor"></span></h2>
-    <p class="step-sub">看你机器上 Camoufox / xvfb-run / Playwright 装没装。</p>
+    <p class="step-sub">看你机器上 Camoufox / Playwright 装没装；Linux 无桌面时再检查 xvfb-run。</p>
 
     <div class="step-actions">
       <TermBtn :loading="loading" @click="run">重新检查</TermBtn>

--- a/webui/frontend/src/components/steps/Step14_Review.vue
+++ b/webui/frontend/src/components/steps/Step14_Review.vue
@@ -25,7 +25,8 @@
           备份：{{ result.backups.join(", ") }}
         </div>
       </div>
-      <pre class="export-cmd">xvfb-run -a python pipeline.py --config {{ relPath(result.pay_path) }} --paypal</pre>
+      <pre class="export-cmd">python pipeline.py --config {{ relPath(result.pay_path) }} --paypal</pre>
+      <div class="export-note">Linux 无桌面环境时，可改成 <code>xvfb-run -a python ...</code>。</div>
       <TermBtn @click="goRun" style="margin-top:12px">立即在 Web 里运行 →</TermBtn>
     </div>
   </section>
@@ -117,6 +118,16 @@ function goRun() {
   margin-top: 8px;
   font-size: 12px;
   color: var(--ok);
+}
+.export-note {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--fg-tertiary);
+}
+.export-note code {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  padding: 1px 4px;
 }
 .export-path { padding: 2px 0; }
 .export-cmd {

--- a/webui/frontend/src/views/Run.vue
+++ b/webui/frontend/src/views/Run.vue
@@ -379,7 +379,7 @@ const status = ref<RunStatus>({
   started_at: null, ended_at: null, exit_code: null, log_count: 0,
 });
 
-const cmdPreview = ref("xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal");
+const cmdPreview = ref("python -u pipeline.py --config CTF-pay/config.paypal.json --paypal");
 const lines = ref<{ seq: number; ts: number; line: string }[]>([]);
 const starting = ref(false);
 const stopping = ref(false);

--- a/webui/tests/test_preflight_system.py
+++ b/webui/tests/test_preflight_system.py
@@ -25,3 +25,16 @@ def test_system_preflight_each_check_has_status(client):
 def test_system_preflight_requires_auth(client):
     r = client.post("/api/preflight/system", json={})
     assert r.status_code == 401
+
+
+def test_system_preflight_allows_missing_xvfb_on_macos(monkeypatch):
+    import webui.backend.preflight.system as system_mod
+
+    monkeypatch.setattr(system_mod.runtime_env.sys, "platform", "darwin")
+    monkeypatch.setattr(system_mod.shutil, "which", lambda name: "/usr/local/bin/camoufox" if name == "camoufox" else None)
+    monkeypatch.setattr(system_mod.runtime_env, "xvfb_check", lambda: ("ok", "macOS 不需要 xvfb-run；将直接启动 python"))
+
+    body = system_mod.check()
+    xvfb = next(c for c in body.checks if c.name == "xvfb-run")
+    assert xvfb.status == "ok"
+    assert "macOS" in xvfb.message

--- a/webui/tests/test_run.py
+++ b/webui/tests/test_run.py
@@ -21,7 +21,8 @@ def test_run_preview_single(client):
     r = client.post("/api/run/preview", json={"mode": "single"})
     assert r.status_code == 200
     body = r.json()
-    assert "xvfb-run" in body["cmd_str"]
+    assert body["cmd"][0] in ("python", "xvfb-run")
+    assert "python" in body["cmd"]
     assert "pipeline.py" in body["cmd_str"]
     assert "--paypal" in body["cmd_str"]
 
@@ -127,6 +128,26 @@ def test_run_start_then_409(client, monkeypatch):
 
     # Cleanup module state
     runner_mod._proc = None
+
+
+def test_build_cmd_uses_xvfb_on_linux_when_available(monkeypatch):
+    import webui.backend.runner as runner_mod
+
+    monkeypatch.setattr(runner_mod.runtime_env.sys, "platform", "linux")
+    monkeypatch.setattr(runner_mod.runtime_env.shutil, "which", lambda name: "/usr/bin/xvfb-run" if name == "xvfb-run" else None)
+
+    cmd = runner_mod.build_cmd("single", True, 0, 3, 0, False, False)
+    assert cmd[:4] == ["xvfb-run", "-a", "python", "-u"]
+
+
+def test_build_cmd_skips_xvfb_on_macos(monkeypatch):
+    import webui.backend.runner as runner_mod
+
+    monkeypatch.setattr(runner_mod.runtime_env.sys, "platform", "darwin")
+    monkeypatch.setattr(runner_mod.runtime_env.shutil, "which", lambda name: None)
+
+    cmd = runner_mod.build_cmd("single", True, 0, 3, 0, False, False)
+    assert cmd[:2] == ["python", "-u"]
 
 
 def test_gopay_auto_otp_skips_manual_fifo(tmp_path, monkeypatch):


### PR DESCRIPTION
## 1. 改动类型（必填）

- [x] 🔧 **工具链 / CI**

---

## 2. 改动摘要（必填）

更新WebUI pipeline runner的执行逻辑，确保在Linux系统上选择使用`xvfb-run -a`，而在macOS上不需要此步骤，并更新相关的UI文档。

**关闭 issue（如适用）**：Closes #

---

## 3. 详细说明 + 设计决策（必填，至少 100 字）

当前的实现要求在所有操作系统上都执行`xvfb-run -a`，但在macOS上并不需要此工具。这个PR解决了这一问题，修改了WebUI pipeline runner逻辑，使其仅在Linux系统上使用`xvfb-run -a`，而在macOS系统上则不需要，提升了跨平台兼容性和运行效率。同时，更新了UI和文档中的相关描述，明确指出macOS无需依赖`xvfb-run`。这个改动确保了项目在不同操作系统上的平滑运行，并提升了用户体验。

---

## 4. 跑通证据（**必填**，按你 PR 类型不同要求不同）

### A. 通用要求（所有 PR 都要）

- [x] **本地跑过这个 PR 的代码**（不是只通过 review 改的字面）
- [x] **没引入新的真实凭证 / IP / 域名 / PII** —— `git diff main...HEAD` 自查过

### B. 按类型补充证据

#### 🔧 工具链 / CI

- [x] **复现命令**：
  ```bash
  # 在Linux系统上跑通：
  xvfb-run -a pytest webui/tests/test_run.py webui/tests/test_preflight_system.py
  # 在macOS上跑通：
  pytest webui/tests/test_run.py webui/tests/test_preflight_system.py