### PR TITLE
Fix browser OTP issued-after timestamp

### DIFF
--- a/CTF-reg/browser_register.py
+++ b/CTF-reg/browser_register.py
@@ -120,6 +120,8 @@ def browser_register(cfg, mail_provider) -> dict:
         "cookie_header": "",
     }
 
+    otp_sent_at: Optional[float] = None
+
     try:
         with Camoufox(
             headless=not has_display,
@@ -230,6 +232,7 @@ def browser_register(cfg, mail_provider) -> dict:
                         'button:has-text("Next")']:
                 b = page.query_selector(sel)
                 if b and b.is_visible():
+                    otp_sent_at = time.time()
                     b.click()
                     logger.info(f"[browser-reg] 点击 email 继续: {sel}")
                     break
@@ -252,6 +255,7 @@ def browser_register(cfg, mail_provider) -> dict:
                             'button:has-text("Create")', 'button:has-text("Next")']:
                     b = page.query_selector(sel)
                     if b and b.is_visible():
+                        otp_sent_at = time.time()
                         b.click()
                         logger.info(f"[browser-reg] 点击 password 继续: {sel}")
                         break
@@ -283,7 +287,8 @@ def browser_register(cfg, mail_provider) -> dict:
             if page.query_selector('input[autocomplete="one-time-code"]') or \
                page.query_selector('input[inputmode="numeric"]'):
                 logger.info("[browser-reg] 等待 IMAP OTP ...")
-                otp_sent_at = time.time()
+                if otp_sent_at is None:
+                    otp_sent_at = time.time()
                 try:
                     otp_timeout = max(30, int(os.getenv("OTP_TIMEOUT", "180")))
                 except Exception:


### PR DESCRIPTION
## 1. 改动类型（必填）

- [x] 🐛 **Bug fix** — 修了某个会让现有用户配置失效的行为

---

## 2. 改动摘要（必填）

修复浏览器注册流程中的OTP时效问题，确保在提交邮箱/密码时记录OTP发放时间，而非OTP页面加载完毕时，同时仅在没有早期发放点的路径上保留OTP等待回退。

**关闭 issue（如适用）**：Closes #

---

## 3. 详细说明 + 设计决策（必填，至少 100 字）

在浏览器注册流程中，现有逻辑会在OTP页面加载时记录OTP发放时间，可能会导致OpenAI在发送OTP后，OTP页面尚未加载完毕时，就认为该OTP已过期，导致重复的CF KV轮询和过时阈值日志。此PR将OTP的发放时间改为在提交邮箱/密码时记录，而不是在OTP页面加载时记录。与此同时，仅当没有更早的发放点时，才保留OTP等待回退的机制。这一修改能够避免OTP被错误地认为已过期，并减少不必要的重复轮询。

---

## 4. 跑通证据（**必填**，按你 PR 类型不同要求不同）

### A. 通用要求（所有 PR 都要）

- [x] **本地跑过这个 PR 的代码**（不是只通过 review 改的字面）
- [x] **没引入新的真实凭证 / IP / 域名 / PII** —— `git diff main...HEAD` 自查过

### B. 按类型补充证据

#### 🐛 Bug fix

- [x] **复现命令**：
  ```bash
  # 重现该问题的步骤：
  1. 提交注册时的邮箱/密码，未等OTP页面完全加载。
  2. 查看CF KV轮询日志，重复的过时阈值日志。
  ```

- [x] **修复前的失败日志**：
  <details><summary>失败日志</summary>

  ```text
  [reg] 09:08:22 [INFO] browser_register: [browser-reg] 已到达 OTP 页面
  [reg] 09:08:22 [INFO] browser_register: [browser-reg] 等待 IMAP OTP ...
  [reg] 09:08:22 [INFO] mail_provider: [mail] 走 CF KV 取 OTP -> rcuqn4g@xxxx.com (timeout=180s)
  [reg] 09:08:23 [INFO] cf_kv_otp_provider: [CF-KV] 等 OTP key=rcuqn4g@xxxx.com timeout=180s (issued_after=1777856903)
  [reg] 09:08:24 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:08:35 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:08:45 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:08:56 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:09:08 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:09:19 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:09:31 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:09:45 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:09:56 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:10:07 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:10:24 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:10:34 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:10:47 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:11:00 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  [reg] 09:11:12 [INFO] cf_kv_otp_provider: [CF-KV] key=rcuqn4g@xxxx.com 命中但 ts=1777856872 < threshold=1777856900，忽略旧值
  ```
  </details>

- [x] **修复后的成功日志**：
  <details><summary>成功日志</summary>

  ```
  [reg] 13:10:50 [INFO] mail_provider: [mail] 走 CF KV 取 OTP -> lhruh35n@xxxx.com (timeout=180s)
  [reg] 13:10:51 [INFO] cf_kv_otp_provider: [CF-KV] 等 OTP key=lhruh35n@xxxx.com timeout=180s (issued_after=1777871412)
  [reg] 13:10:51 [INFO] cf_kv_otp_provider: [CF-KV] 收到 OTP=530191 key=lhruh35n@xxxx.com poll#1 elapsed=0.9s from='bounces+20216706-eed3-lhruh35n=xxxx.com@em7877.tm.openai.co'
  [reg] 13:10:53 [INFO] browser_register: [browser-reg] 收到 OTP: 530191
  [reg] 13:10:57 [INFO] browser_register: [browser-reg] 点击 OTP 继续: button[type="submit"]
  ```
  </details>

- [x] **描述边界情况**：在OTP页面加载之前提交邮箱/密码，确认OTP不被错误标记为“过期”。

---

## 5. Reviewer 怎么本地验证（必填）

1. checkout 这个分支
2. 模拟注册流程，提交邮箱/密码，并确保OTP页面还未完全加载时：
   ```bash
   # 提交邮箱/密码后，检查日志是否显示正确的OTP发放时间
   ```
3. 验证是否避免了错误的OTP过期标记，并减少了重复CF KV轮询。
4. 检查修复是否正确，不影响有更早发放点的路径。

---

## 6. 测了什么 / 没测什么（必填）

### 已测场景

- [x] 在OTP页面加载之前提交邮箱/密码，验证OTP不再被错误标记为过期。
- [x] 在没有更早发放点的路径上，保留了OTP等待回退机制。

### 已知没覆盖的边界

- [x] 未对所有可能路径的时间戳记录方式进行全面测试。

---

## 7. 脱敏检查（**必填强制勾选**）

- [x] 我搜过本 PR 所有改动里的真实 IP，全部用 `203.0.113.x` / `198.51.100.x` / `192.0.2.x` 替换了
- [x] 我搜过所有改动里的真实域名，全部用 `*.example` 替换了
- [x] 我搜过所有改动里的真实邮箱、token、cookie、卡号，全部脱敏或删除了
- [x] 我跑过 `git diff --cached` 检查没有真实凭证带进 stage
- [x] 本 PR 描述里贴的所有日志 / 截图都已脱敏

---

## 8. 授权与 License 确认（**必填强制勾选**）

- [x] 我贡献的内容是我自己写的，或者来自符合 MIT 兼容许可证的来源
- [x] 我同意贡献按本项目的 [MIT License](../LICENSE) 发布
- [x] 我已经读过并接受 [`NOTICE`](../NOTICE) 的全部条款
- [x] 我已经读过 [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md)
- [x] 这个 PR **不是**为了协助任何针对未授权目标的使用
- [x] 这个 PR 涉及的研究 / 数据 / 实验都是在我自己拥有或明确授权的目标上做的

---

## 9. 其他（可选）

- 计划进一步验证其他路径的OTP发放时间记录。

---

> 提交前最后检查：上面所有 **必填** 项都填了？所有 **强制勾选** 项都勾了？跑通证据按你的 PR 类型给齐了？没填全的 PR 会被打 `needs-info` 标签，超过 14 天没补全自动关闭。