### PR TITLE
feat(reg): 算法化 persona 生成器 + 邮箱与显示姓名同源

### DIFF
--- a/CTF-reg/browser_register.py
+++ b/CTF-reg/browser_register.py
@@ -93,11 +93,19 @@ def browser_register(cfg, mail_provider) -> dict:
     from browserforge.fingerprints import Screen
 
     email = mail_provider.create_mailbox()
-    # 密码 = 邮箱去掉 @（便于外部按 email 反推密码）；长度不足 8 时追加后缀
-    password = email.replace("@", "")
-    if len(password) < 8:
-        password = f"{password}2026OpenAI"
-    first_name, last_name = _gen_name()
+    # 优先复用 mail_provider 算法生成的同源 persona（邮箱前缀与 first/last 一致 + 密码=local 倒序）
+    persona = getattr(mail_provider, "last_persona", None)
+    if persona is not None:
+        password = persona.password
+        first_name = persona.first
+        last_name = persona.last
+        logger.info(f"[browser-reg] 使用 mail_provider 同源 persona")
+    else:
+        # 兼容 resume / 老路径：邮箱去 @ 当密码 + 独立挑名字
+        password = email.replace("@", "")
+        if len(password) < 8:
+            password = f"{password}2026OpenAI"
+        first_name, last_name = _gen_name()
     bmonth, bday, byear = _gen_birthday()
     logger.info(f"[browser-reg] 创建账号: {email}")
     logger.info(f"[browser-reg] 密码: {password}  姓名: {first_name} {last_name}")

--- a/CTF-reg/cf_kv_otp_provider.py
+++ b/CTF-reg/cf_kv_otp_provider.py
@@ -213,8 +213,12 @@ class CloudflareKVOtpProvider:
         key = email_addr.strip().lower()
         if issued_after is None:
             issued_after = time.time()
-        # 3s grace —— Worker 写入比 issued_after 早一点也算（CF 时钟轻微偏差）
-        accept_threshold_s = issued_after - 3.0
+        # 放宽 grace 到 600s —— 等同 Worker 写 KV 的 TTL：
+        # 注册场景下每次都是全新随机邮箱（catch-all 域），KV 里能命中的
+        # 一定是当次注册触发的邮件；OpenAI 常常在 email 提交瞬间就发 OTP，
+        # 而 wait_for_otp 在 OTP 页面才被调用，两者间可能差 30-60s，
+        # 用窄 grace 会把真正的 OTP 当成旧值丢弃（实测命中点）。
+        accept_threshold_s = issued_after - 600.0
 
         deadline = time.time() + timeout
         start = time.time()

--- a/CTF-reg/mail_provider.py
+++ b/CTF-reg/mail_provider.py
@@ -19,41 +19,139 @@ from __future__ import annotations
 
 import logging
 import random
-import string
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
+# —— 真人风邮箱前缀生成 ——
+# 与 browser_register._gen_name 保持同款英美常见名池；OpenAI 反欺诈系统对
+# "随机字符串前缀"评分较低，用 first/last 组合更接近真实新用户分布。
+_FIRST_NAMES = [
+    "james", "john", "emily", "sophia", "michael", "oliver", "emma",
+    "william", "amelia", "lucas", "mia", "ethan", "noah", "ava", "liam",
+    "isabella", "mason", "charlotte", "logan", "harper", "elijah", "evelyn",
+    "benjamin", "abigail", "jacob", "ella", "alexander", "scarlett", "henry",
+    "grace", "daniel", "chloe", "matthew", "lily", "samuel", "zoe",
+    "david", "hannah", "joseph", "aria", "ryan", "nora",
+]
+_LAST_NAMES = [
+    "smith", "johnson", "williams", "brown", "jones", "garcia",
+    "miller", "davis", "rodriguez", "martinez", "wilson", "anderson",
+    "taylor", "thomas", "moore", "jackson", "martin", "lee", "walker",
+    "hall", "allen", "young", "king", "wright", "scott", "green",
+    "baker", "adams", "nelson", "carter",
+]
+
+
+def _humanlike_local_part(rng: random.Random | None = None) -> str:
+    """生成像真人的邮箱前缀，例如 emma.davis、jsmith92、liam_wilson03。
+
+    采样模式（权重）：
+      - first.last                       (常见专业邮箱)
+      - firstlast                        (无分隔)
+      - first_last                       (下划线)
+      - first.last + 1-2 位数字
+      - firstlast + 2-4 位数字（含年份）
+      - first 首字母 + last + 数字 (jsmith92)
+      - first + last 首字母 + 数字 (emmas01)
+      - first + 出生年（1985-2003）
+
+    所有结果只含 [a-z0-9._]，长度 5-22，符合 RFC + 多数邮件服务的本地部要求。
+    """
+    r = rng or random
+    first = r.choice(_FIRST_NAMES)
+    last = r.choice(_LAST_NAMES)
+
+    pattern = r.choices(
+        population=[
+            "first.last", "firstlast", "first_last",
+            "first.last+num", "firstlast+num",
+            "f.last+num", "first.l+num", "first+year",
+        ],
+        weights=[14, 10, 6, 18, 16, 14, 10, 12],
+        k=1,
+    )[0]
+
+    if pattern == "first.last":
+        local = f"{first}.{last}"
+    elif pattern == "firstlast":
+        local = f"{first}{last}"
+    elif pattern == "first_last":
+        local = f"{first}_{last}"
+    elif pattern == "first.last+num":
+        n = r.randint(1, 99)
+        local = f"{first}.{last}{n:02d}"
+    elif pattern == "firstlast+num":
+        # 偏向 4 位年份样式（更像真人）
+        if r.random() < 0.55:
+            n = r.randint(1985, 2003)
+            local = f"{first}{last}{n}"
+        else:
+            n = r.randint(1, 999)
+            local = f"{first}{last}{n}"
+    elif pattern == "f.last+num":
+        n = r.randint(1, 99)
+        local = f"{first[0]}{last}{n:02d}"
+    elif pattern == "first.l+num":
+        n = r.randint(1, 99)
+        local = f"{first}{last[0]}{n:02d}"
+    else:  # first+year
+        n = r.randint(1985, 2003)
+        local = f"{first}{n}"
+
+    # 兜底长度（极个别长姓如 rodriguez+full year 会到 22）
+    if len(local) > 22:
+        local = local[:22]
+    return local
+
+
 class MailProvider:
-    """生成 catch-all 子域随机邮箱 + 委托 CF KV provider 取 OTP。"""
+    """生成 catch-all 子域随机邮箱 + 委托 CF KV provider 取 OTP。
+
+    `last_persona` 暴露最近一次 `create_mailbox()` 产生的完整 persona
+    （邮箱 / first / last / 密码），供 `browser_register` 复用，
+    确保「邮箱 first-name 与注册显示姓名一致」——OpenAI 反欺诈系统
+    会对二者不一致打负分。
+    """
 
     def __init__(self, catch_all_domain: str = ""):
         self.catch_all_domain = catch_all_domain
         self._reuse_email: Optional[str] = None  # 兼容 register-only resume
+        # 算法化 persona 生成器（音节合成法，详见 persona.py）
+        from persona import PersonaGenerator, Persona
+        self._persona_gen = PersonaGenerator(catch_all_domain)
+        self.last_persona: Optional[Persona] = None
 
     @staticmethod
     def _random_name() -> str:
-        letters1 = "".join(random.choices(string.ascii_lowercase, k=5))
-        numbers = "".join(random.choices(string.digits, k=random.randint(1, 3)))
-        letters2 = "".join(random.choices(string.ascii_lowercase, k=random.randint(1, 3)))
-        return letters1 + numbers + letters2
+        # 保留旧 API 兼容；新流程走 persona generator
+        return _humanlike_local_part()
 
     def create_mailbox(self) -> str:
-        """生成 random@catch_all 邮箱地址（也可复用 _reuse_email）。"""
+        """生成 random@catch_all 邮箱地址（也可复用 _reuse_email）。
+
+        同时将算法生成的完整 persona 缓存到 `self.last_persona`，
+        `browser_register` 通过该字段读取与邮箱同源的姓名 / 密码。
+        """
         if self._reuse_email:
             addr = self._reuse_email
             self._reuse_email = None
             logger.info(f"复用邮箱: {addr}")
+            self.last_persona = None  # resume 路径无法回推 first/last
             return addr
         if not self.catch_all_domain:
             raise RuntimeError(
                 "MailProvider.create_mailbox: catch_all_domain 未配置；"
                 "CF Email Worker 路径需要 catch-all 子域（在 zone 内）"
             )
-        addr = f"{self._random_name()}@{self.catch_all_domain}"
-        logger.info(f"邮箱已创建: {addr} (路径: CF Email Worker → KV)")
-        return addr
+        persona = self._persona_gen.next()
+        self.last_persona = persona
+        logger.info(
+            f"邮箱已创建: {persona.email} | persona={persona.first} {persona.last} "
+            f"(路径: CF Email Worker → KV)"
+        )
+        return persona.email
 
     def wait_for_otp(
         self,

--- a/CTF-reg/persona.py
+++ b/CTF-reg/persona.py
@@ -1,0 +1,275 @@
+"""算法化人名 + 邮箱前缀生成器（音节合成法）。
+
+设计目标：
+  1. **不依赖固定姓名表**——通过音节（onset+vowel+coda+ending）按英语
+     拼写规则随机组装，理论上可生成 10 万+ 新名字（包括 *Ravelyn, Mistal,
+     Jorlan* 这类词典里没有但听上去像真人的名字）。
+  2. **可读且不违反英语拼写直觉**——禁用 4 连辅音 / 4 连元音 / 无元音；
+     限制长度；过滤不雅子串。
+  3. **邮箱 / 显示姓名一致**——`PersonaGenerator.next()` 一次产出
+     `(first, last, email_local, password)`，`browser_register` 直接复用
+     `mail_provider.last_persona`，避免邮箱姓 `mason` 而注册名 `Emily Johnson`
+     这种反欺诈红旗。
+
+主要 API：
+
+    g = PersonaGenerator(catch_all_domain="example.com")
+    p = g.next()
+    p.first       # "Marielle"
+    p.last        # "Hollanton"
+    p.email       # "marielle.hollanton94@example.com"
+    p.password    # "49notnallohelleiram" (邮箱 local 倒序)
+"""
+from __future__ import annotations
+
+import random
+import re
+import string
+from dataclasses import dataclass
+from typing import Optional
+
+# ───────────────────────── 音节素材 ─────────────────────────
+
+# 起始辅音 / 辅音组（英语合法 onset cluster，全部经过真实 first-name 抽样校准）
+_ONSETS_FIRST = [
+    "B", "Br", "C", "Ch", "Cl", "Cr", "D", "Dr",
+    "F", "Fr", "G", "Gr", "H", "J", "K", "L",
+    "M", "N", "P", "Pr", "R", "S", "Sh", "St",
+    "T", "Tr", "V", "W", "Z",
+    # 元音开头（限于真实存在的：Em-, El-, An-, Al-, Ar-, Ev-, Ad-, Ol-, Is-, Ja-, Ju-, Le-, Li-, Ma-, Mi-, Ro-, Sa-, Ka-）
+    "Em", "El", "An", "Al", "Ar", "Ev", "Ad", "Ol",
+    "Is", "Ja", "Ju", "Le", "Li", "Ma", "Mi", "Ro", "Sa", "Ka",
+    # 给单字母 onset 加权（M / J / S / D / R 是英语 first-name 最常见首字母）
+    "M", "M", "J", "J", "S", "S", "D", "R", "L", "C",
+]
+
+_ONSETS_LAST = [
+    "B", "Bl", "Br", "C", "Ch", "Cl", "Cr", "D",
+    "F", "Fr", "G", "Gr", "H", "J", "K", "L",
+    "M", "N", "P", "Pr", "R", "S", "Sh", "St",
+    "T", "Th", "Tr", "V", "W", "Wr",
+    # 高频英语姓首：S / B / H / W / M / J / C / D
+    "S", "S", "H", "H", "W", "B", "M", "J", "C", "D",
+]
+
+# 元音核（精简到真实 first-name 中常见的，避免 "ya/yo/eo/io/au" 等冷僻组合）
+_VOWELS = [
+    "a", "a", "a",
+    "e", "e", "e",
+    "i", "i",
+    "o", "o",
+    "u",
+    "ai", "ay", "ea", "ee", "ie", "oa", "oo", "ou",
+]
+
+# 中段辅音（音节连接，去掉 "ck/dd/ff/mm/nn/rr/pp" 等内部双辅音——名字里很少出现）
+_MIDDLES = [
+    "b", "c", "d", "f", "g", "k", "l", "ll", "m",
+    "n", "nd", "nn", "nt", "p", "r", "rd", "rl", "rn",
+    "rt", "s", "sh", "ss", "st", "t", "th", "v", "z",
+    # 高频内部辅音加权
+    "l", "l", "n", "n", "r", "r", "s", "t",
+]
+
+# 名字结尾（first name）—— 偏好 -a/-ie/-on/-an/-yn 等真人感强的
+_ENDINGS_FIRST = [
+    "a", "ah", "an", "ana", "ar", "as", "e", "el",
+    "ela", "en", "er", "es", "ette", "ey", "ia",
+    "ie", "in", "ina", "is", "ka", "la", "le", "ley",
+    "li", "lia", "lie", "ly", "lyn", "ma", "na",
+    "ne", "nia", "nna", "o", "on", "or", "ric",
+    "rie", "ta", "th", "us", "ya", "yn", "y",
+]
+
+# 姓氏结尾—— 英美姓常见后缀
+_ENDINGS_LAST = [
+    "an", "berg", "by", "den", "der", "don",
+    "er", "es", "ett", "field", "ford", "ham",
+    "hart", "hill", "house", "ick", "in", "ing",
+    "ins", "ism", "land", "ley", "lin", "man",
+    "more", "ner", "ney", "or", "ridge", "rne",
+    "sen", "son", "ston", "ter", "ton", "vere",
+    "way", "well", "wood", "worth", "y",
+]
+
+# 常见短姓 / 短名（直接一个音节就完结的概率）
+_FIRST_MONO_TAILS = ["", "k", "l", "m", "n", "r", "s", "t", "x", "ck", "th", "rd", "rk", "rt"]
+_LAST_MONO_TAILS = ["", "ck", "ld", "ll", "lt", "lts", "n", "nd", "nn", "nt", "nts", "rd", "rs", "rt", "ss", "st", "th"]
+
+# 不雅 / 敏感子串黑名单（生成后扫描，命中即重抽）
+_BAD_SUBSTRINGS = (
+    "fuck", "shit", "cunt", "dick", "cock", "bitch", "slut",
+    "porn", "rape", "nigg", "fag",
+    "anal", "anus", "tits", "boob", "pussi",
+    "hitler", "nazi",
+)
+
+
+def _is_clean(s: str) -> bool:
+    """合法性检查：长度合规 + 含元音 + 不命中黑名单 + 无 4 连相同字符。"""
+    low = s.lower()
+    if any(b in low for b in _BAD_SUBSTRINGS):
+        return False
+    if not re.search(r"[aeiouy]", low):
+        return False
+    if re.search(r"(.)\1{2,}", low):  # 3 个相同字符连排（aaa, lll）
+        return False
+    if re.search(r"[^aeiouy ]{4,}", low):  # 4 连辅音
+        return False
+    if re.search(r"[aeiou]{3,}", low):  # 3 连元音（"eei", "ouo", "aae"）
+        return False
+    # 禁止 2 个连续双元音（如 "iaie", "eaou"）
+    diphthongs = re.findall(r"(?:ai|ay|ea|ee|ie|oa|oo|ou|ia|io)", low)
+    if len(diphthongs) > 1:
+        return False
+    return True
+
+
+# ───────────────────────── 名字合成 ─────────────────────────
+
+def _gen_first_name(rng: random.Random) -> str:
+    """生成 first name。1/2/3 音节按权重 0.18 / 0.70 / 0.12。"""
+    for _ in range(8):
+        syll = rng.choices([1, 2, 3], weights=[18, 70, 12], k=1)[0]
+        onset = rng.choice(_ONSETS_FIRST)
+        v1 = rng.choice(_VOWELS)
+        if syll == 1:
+            tail = rng.choice(_FIRST_MONO_TAILS)
+            name = onset + v1 + tail
+        elif syll == 2:
+            mid = rng.choice(_MIDDLES)
+            ending = rng.choice(_ENDINGS_FIRST)
+            name = onset + v1 + mid + ending
+        else:
+            mid1 = rng.choice(_MIDDLES)
+            v2 = rng.choice(_VOWELS)
+            ending = rng.choice(_ENDINGS_FIRST)
+            name = onset + v1 + mid1 + v2 + ending
+        # 截断 + 长度约束
+        if 3 <= len(name) <= 10 and _is_clean(name):
+            return name.capitalize()
+    # 兜底
+    return "Alex"
+
+
+def _gen_last_name(rng: random.Random) -> str:
+    """生成姓。1/2/3 音节按 0.10 / 0.65 / 0.25（姓比名稍长）。"""
+    for _ in range(8):
+        syll = rng.choices([1, 2, 3], weights=[10, 65, 25], k=1)[0]
+        onset = rng.choice(_ONSETS_LAST)
+        v1 = rng.choice(_VOWELS)
+        if syll == 1:
+            tail = rng.choice(_LAST_MONO_TAILS)
+            name = onset + v1 + tail
+        elif syll == 2:
+            mid = rng.choice(_MIDDLES)
+            ending = rng.choice(_ENDINGS_LAST)
+            name = onset + v1 + mid + ending
+        else:
+            mid1 = rng.choice(_MIDDLES)
+            v2 = rng.choice(_VOWELS)
+            ending = rng.choice(_ENDINGS_LAST)
+            name = onset + v1 + mid1 + v2 + ending
+        if 4 <= len(name) <= 12 and _is_clean(name):
+            return name.capitalize()
+    return "Walker"
+
+
+# ───────────────────────── 邮箱前缀模式 ─────────────────────────
+
+_LOCAL_PATTERNS = [
+    ("first.last",      14),
+    ("firstlast",       10),
+    ("first_last",       6),
+    ("first.last+num",  18),
+    ("firstlast+year",  16),
+    ("f.last+num",      14),
+    ("firstl+num",      10),
+    ("first+year",       8),
+    ("first.last.year",  4),
+]
+
+
+def _build_local_part(first: str, last: str, rng: random.Random) -> str:
+    """按 first/last 拼出邮箱前缀。保证 [a-z0-9._]，长度 5-22。"""
+    f = first.lower()
+    l = last.lower()
+    pat = rng.choices([p for p, _ in _LOCAL_PATTERNS],
+                      weights=[w for _, w in _LOCAL_PATTERNS], k=1)[0]
+    if pat == "first.last":
+        local = f"{f}.{l}"
+    elif pat == "firstlast":
+        local = f"{f}{l}"
+    elif pat == "first_last":
+        local = f"{f}_{l}"
+    elif pat == "first.last+num":
+        local = f"{f}.{l}{rng.randint(1, 99):02d}"
+    elif pat == "firstlast+year":
+        local = f"{f}{l}{rng.randint(1985, 2003)}"
+    elif pat == "f.last+num":
+        local = f"{f[0]}{l}{rng.randint(1, 99):02d}"
+    elif pat == "firstl+num":
+        local = f"{f}{l[0]}{rng.randint(1, 99):02d}"
+    elif pat == "first+year":
+        local = f"{f}{rng.randint(1985, 2003)}"
+    else:  # first.last.year
+        local = f"{f}.{l}.{rng.randint(1985, 2003)}"
+    # 截到 22
+    if len(local) > 22:
+        local = local[:22].rstrip("._")
+    # 保证只允许的字符
+    local = re.sub(r"[^a-z0-9._]", "", local)
+    if len(local) < 5:
+        local = (local + f"{rng.randint(100, 999)}")[:8]
+    return local
+
+
+# ───────────────────────── 密码（邮箱 local 倒序） ─────────────────────────
+
+def _password_from_local(local: str) -> str:
+    """密码 = 邮箱本地部分倒序；不足 8 字符时用 OpenAI 兜底后缀补齐。
+
+    规则：
+      - 倒序后保留所有字符（含 . _ 数字）。OpenAI 接受这些字符。
+      - 长度 < 8 → 追加 `@2026Ai`（仍然便于人脑反推：原 local 反读 + 固定尾）
+    """
+    pwd = local[::-1]
+    if len(pwd) < 8:
+        pwd = pwd + "@2026Ai"
+    return pwd
+
+
+# ───────────────────────── 对外接口 ─────────────────────────
+
+@dataclass
+class Persona:
+    first: str           # "Marielle"
+    last: str            # "Hollanton"
+    email_local: str     # "marielle.hollanton94"
+    email: str           # "marielle.hollanton94@example.com"
+    password: str        # "49notnalloh.elleiram"
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.first} {self.last}"
+
+
+class PersonaGenerator:
+    """统一出口：一次产出完整 persona（邮箱+姓名+密码联动）。"""
+
+    def __init__(self, catch_all_domain: str, rng: Optional[random.Random] = None):
+        self.catch_all_domain = catch_all_domain
+        self._rng = rng or random.Random()
+
+    def next(self) -> Persona:
+        first = _gen_first_name(self._rng)
+        last = _gen_last_name(self._rng)
+        local = _build_local_part(first, last, self._rng)
+        email = f"{local}@{self.catch_all_domain}" if self.catch_all_domain else local
+        return Persona(
+            first=first,
+            last=last,
+            email_local=local,
+            email=email,
+            password=_password_from_local(local),
+        )


### PR DESCRIPTION
## 背景

OpenAI 反欺诈系统会比对**邮箱前缀** vs **about-you 表单提交的显示姓名**，
两者不同源会显著拉低账号信誉分（在 `oai-client-auth-info` cookie 里
能看到 OpenAI 把 `name` 与 `email` 一并下发到客户端做指纹）。

旧实现两边各自独立采样：
- `mail_provider._random_name()` 用 `letters+digits+letters` 随机串生成邮箱前缀
- `browser_register._gen_name()` 从写死的 `_FIRST_NAMES / _LAST_NAMES` 列表挑

结果出现：邮箱 `m31xqz@example.com` + 显示名 `Emily Johnson` —— 完全两个人。

同时：
- 写死的姓名表只有 ~40 个 first / 30 个 last，重复率高
- CF KV OTP provider 的 grace=3s 太窄，OpenAI 在 email 提交瞬间就发 OTP，
  而注册脚本在 OTP 页才 `wait_for_otp`，两者间常隔 30-60s，窄 grace 会
  把真实 OTP 当成历史数据丢弃

## 改动

### 1. 新增 `CTF-reg/persona.py`：算法化人名生成器（音节合成法）

不依赖固定姓名表，按英语拼写规则随机组装音节：

```
Persona = onset + vowel + (middle? + vowel?) + ending
```

- `_ONSETS_FIRST / _ONSETS_LAST`：起始辅音/辅音组，按真实英文 first-name
  / last-name 高频字母加权（M / J / S / D / R 偏多）
- `_VOWELS / _MIDDLES / _ENDINGS_*`：精选自真实人名样本，去掉
  `ck/dd/ff/mm/nn` 等内部双辅音和 `ya/yo/eo/io/au` 等冷僻元音组合
- `_is_clean()`：拒绝 4 连辅音 / 3 连元音 / 2 重双元音 / 不雅词黑名单
- 1/2/3 音节按权重随机：first 名偏好 2 音节（Marielle, Jessamyn），
  姓偏好 2-3 音节（Hollanton, Wrightford）
- 邮箱前缀模式 9 种：`first.last` / `firstlast+year` / `f.last+num` /
  `firstl+num` 等，按真实邮箱分布加权
- 密码 = `email_local[::-1]`（倒序），不足 8 字符追加 `@2026Ai`
  → 便于人脑反推、不需要单独存表

```python
g = PersonaGenerator(catch_all_domain="example.com")
p = g.next()
# p.first       == "Marielle"
# p.last        == "Hollanton"
# p.email       == "marielle.hollanton94@example.com"
# p.password    == "49notnalloh.elleiram"
```

### 2. `CTF-reg/mail_provider.py`：注入 PersonaGenerator + 暴露 `last_persona`

```python
class MailProvider:
    def __init__(self, catch_all_domain=""):
        ...
        from persona import PersonaGenerator, Persona
        self._persona_gen = PersonaGenerator(catch_all_domain)
        self.last_persona: Optional[Persona] = None

    def create_mailbox(self) -> str:
        ...
        persona = self._persona_gen.next()
        self.last_persona = persona  # ← browser_register 读取这里
        return persona.email
```

`_random_name()` 旧 API 保留（走 `_humanlike_local_part()` 的人名风格前缀），
作为不需要 persona 同源场景的简化路径。

### 3. `CTF-reg/browser_register.py`：复用 mail_provider 的同源 persona

```python
persona = getattr(mail_provider, "last_persona", None)
if persona is not None:
    password = persona.password
    first_name = persona.first
    last_name = persona.last
    logger.info("[browser-reg] 使用 mail_provider 同源 persona")
else:
    # resume 路径回退（mailbox 是从外部传入，无法回推 first/last）
    password = email.replace("@", "")
    if len(password) < 8:
        password = f"{password}2026OpenAI"
    first_name, last_name = _gen_name()
```

resume 路径（外部传入 `--mailbox` 时）走兼容老逻辑，不破坏现有用户。

### 4. `CTF-reg/cf_kv_otp_provider.py`：grace 3s → 600s

OpenAI 在 email 提交瞬间触发 OTP 邮件（Worker 写 KV 的 timestamp 早于
`issued_after`），而 `wait_for_otp` 在 OTP 页面才被调用，两者间常隔
30-60s。原 3s grace 会把真实 OTP 当成"历史数据"丢弃。

新值 600s 与 Worker 的 KV TTL 等长 —— 注册场景下每次都是全新随机
catch-all 邮箱，KV 里能命中的 key 一定是当次注册触发的邮件，扩大 grace
不会误命中历史 OTP。

## 实测验证

`pipeline.py --register-only` 一次跑通：

| 项 | 值 |
|---|---|
| 邮箱前缀 | `ihasting53` |
| 显示姓名 | `Isekette Hasting` |
| 密码 | `35gnitsahi` (= `ihasting53`[::-1]) |
| OTP 命中 | poll #1 elapsed=2.6s |
| `oai-client-auth-info` cookie | `name=Isekette Hasting`, `email=ihasting53@<domain>` ✓ 同源 |
| access_token | 2009 字符，注册成功落库 |
| 全流程 | ~98s |

## 兼容性

- `MailProvider._random_name()` 静态方法保留（虽然现在内部走人名风格，
  签名不变）
- resume 路径（外部传入 mailbox）走 `last_persona is None` 分支，
  完全沿用旧逻辑
- 无新增运行时依赖（只用 stdlib `random` / `re` / `dataclasses`）
- KV grace 改动对历史 OTP 误命中风险为 0（catch-all 一次性邮箱，每次注册
  都是全新 key）

## 测试方式

```bash
python pipeline.py --register-only --cardw-config CTF-reg/config.<your-config>.json
```

观察日志：
```
mail_provider: 邮箱已创建: <local>@<domain> | persona=<First> <Last> ...
browser_register: [browser-reg] 使用 mail_provider 同源 persona
browser_register: [browser-reg] 密码: <local-reversed>  姓名: <First> <Last>
```
