### PR TITLE
docs(readme): 加代码贡献者 section + 7 位新打赏致谢

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal --da
 - [OpenAI CLIP](https://github.com/openai/CLIP) — 启发式 solver 的视觉骨架
 - [gost](https://github.com/go-gost/gost) — SOCKS5 中继
 
+### 代码贡献者
+
+感谢以下朋友贡献代码（按 PR 时间）：
+
+- [@Lium-7768](https://github.com/Lium-7768) — [#12](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/12) Align GoPay step visibility to hide 06 and 13
+- [@DragonBaiMo](https://github.com/DragonBaiMo) — [#15](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/15) 算法化 persona 生成器 + 邮箱姓名同源
+- [@laochendeai](https://github.com/laochendeai) — [#21](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/21) detect blocking challenge pages
+
 ## 社区
 
 | 渠道 | 用途 |
@@ -242,6 +250,13 @@ xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal --da
 | bensema | 0.66 元 |
 | Earth NPC | 0.01 元 |
 | 小水獭 | 0.01 元 |
+| 至上松一 | 6.66 元 |
+| 书忆江南 | 5 元 |
+| A. | 10 元 |
+| 辛昊 | 5 元 |
+| Galaxy-n | 101 元 |
+| 朴朴配送员 | 66 元 |
+| acedia | 9.1 元 |
 
 心意比金额更珍贵，每一份支持都是项目继续维护的动力 🙏
 


### PR DESCRIPTION
## Summary

- 加 `### 代码贡献者` 小节，列 PR #12 / #15 / #21 三位作者
- `### 打赏致谢` 表格扩展 7 行（至上松一 / 书忆江南 / A. / 辛昊 / Galaxy-n / 朴朴配送员 / acedia）

## 背景

GitHub 主页 Contributors widget 用的是 GraphQL `mentionableUsers` 节点，跟 REST `/contributors` 数据源不一致。@DragonBaiMo（PR #15 作者）git history author 字段保留正常，但 UI 板把他过滤掉（推测平台反垃圾启发式判定，账号 72 repos / 2 followers / 无 name 命中常见标记模式）。手写致谢小节作为对冲，跟"打赏致谢"section 对称。

## Test plan

- [x] 改动是纯文档，不影响代码
- [x] 没破坏现有锚点链接（README ToC 不引用这些小节）
- [x] markdown 表格语法正确