### PR TITLE
fix(webui): support prefixed API routes

### DIFF
--- a/webui/server.py
+++ b/webui/server.py
@@ -25,25 +25,34 @@ FRONTEND_DIST = Path(__file__).parent / "frontend" / "dist"
 
 def create_app() -> FastAPI:
     app = FastAPI(title="Gpt-Agreement-Payment webui")
-    app.include_router(setup_routes.router)
-    app.include_router(auth_routes.router)
-    app.include_router(wizard_routes.router)
-    app.include_router(preflight_routes.router)
-    app.include_router(sniff_routes.router)
-    app.include_router(config_routes.router)
-    app.include_router(inventory_routes.router)
-    app.include_router(run_routes.router)
-    app.include_router(run_parallel_routes.router)
-    app.include_router(cf_kv_routes.router)
-    app.include_router(whatsapp_routes.router)
-    app.include_router(link_state_routes.router)
-    app.include_router(proxy_routes.router)
-    app.include_router(auto_loop_routes.router)
-    app.include_router(outlook_routes.router)
-    app.include_router(promo_links_routes.router)
+    api_routers = [
+        setup_routes.router,
+        auth_routes.router,
+        wizard_routes.router,
+        preflight_routes.router,
+        sniff_routes.router,
+        config_routes.router,
+        inventory_routes.router,
+        run_routes.router,
+        run_parallel_routes.router,
+        cf_kv_routes.router,
+        whatsapp_routes.router,
+        link_state_routes.router,
+        proxy_routes.router,
+        auto_loop_routes.router,
+        outlook_routes.router,
+        promo_links_routes.router,
+    ]
+    for router in api_routers:
+        app.include_router(router)
+        app.include_router(router, prefix="/webui")
 
     @app.get("/api/healthz")
     def healthz():
+        return {"status": "ok"}
+
+    @app.get("/webui/api/healthz")
+    def healthz_webui():
         return {"status": "ok"}
 
     if FRONTEND_DIST.exists():

--- a/webui/tests/test_auth.py
+++ b/webui/tests/test_auth.py
@@ -10,6 +10,18 @@ def test_login_sets_session_cookie(client):
     assert "session_id" in r.cookies
 
 
+def test_login_webui_prefixed_api(client):
+    client.post("/webui/api/setup", json={"username": "admin", "password": "hunter2hunter2"})
+    r = client.post("/webui/api/login", json={"username": "admin", "password": "hunter2hunter2"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert "session_id" in r.cookies
+
+    r = client.get("/webui/api/me")
+    assert r.status_code == 200
+    assert r.json() == {"username": "admin"}
+
+
 def test_login_wrong_password(client):
     _setup(client)
     r = client.post("/api/login", json={"username": "admin", "password": "wrong"})

--- a/webui/tests/test_setup.py
+++ b/webui/tests/test_setup.py
@@ -13,6 +13,20 @@ def test_setup_creates_admin_then_status_initialized(client):
     assert r.json() == {"initialized": True}
 
 
+def test_setup_webui_prefixed_api(client):
+    r = client.get("/webui/api/setup/status")
+    assert r.status_code == 200
+    assert r.json() == {"initialized": False}
+
+    r = client.post("/webui/api/setup", json={"username": "admin", "password": "hunter2hunter2"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+    r = client.get("/webui/api/setup/status")
+    assert r.status_code == 200
+    assert r.json() == {"initialized": True}
+
+
 def test_setup_rejects_second_call(client):
     client.post("/api/setup", json={"username": "admin", "password": "hunter2hunter2"})
     r = client.post("/api/setup", json={"username": "user", "password": "yyyyyyyyy"})


### PR DESCRIPTION
## Summary

- 同一組 FastAPI API router 同時掛到 `/api/...` 和 `/webui/api/...`。
- 修復前端 production build 使用 `/webui/` base path 時，setup / login API 打到 `/webui/api/...` 會 404 / 405 的問題。
- 補上 setup、login 的 `/webui/api` regression tests，保留原本 `/api/...` 行為不變。

## 為什麼要改

Vite production build 目前預設 `BASE_URL=/webui/`，所以前端會呼叫 `/webui/api/setup/status`、`/webui/api/setup`、`/webui/api/login`。但後端原本只註冊 `/api/...`，`/webui/api/setup/status` 會落到 SPA fallback 變成 404，POST `/webui/api/setup` / `/webui/api/login` 則沒有對應的 POST route，變成 405。

這個 PR 選擇把既有 API router 另掛一份 `/webui` prefix，而不是改前端 base URL，原因是 server.py 已經同時支援 `/assets` 和 `/webui/assets`，SPA 也同時支援 `/` 和 `/webui/`。API 跟著雙掛可以讓直接本機存取與 reverse-proxy `/webui/` 部署都維持一致。

## 修復前失敗紀錄

```text
GET /webui/api/setup/status HTTP/1.1 404 Not Found
POST /webui/api/setup HTTP/1.1 405 Method Not Allowed
POST /webui/api/login HTTP/1.1 405 Method Not Allowed
```

## 重現方式

```bash
docker compose up -d --build
# 瀏覽器開 http://127.0.0.1:8765/webui/setup
# setup status 會請求 /webui/api/setup/status；提交表單會 POST /webui/api/setup
```

## 測試

```bash
python -m pytest webui/tests/test_setup.py webui/tests/test_auth.py -q
git diff --check
```

結果：

```text
10 passed, 2 warnings in 3.64s
```

## 未覆蓋 / 已知限制

完整 `python -m pytest webui/tests -q` 在我本機沒有跑完，collection 階段缺測試依賴 `responses` 和 `respx`。這次實際改動覆蓋的是 setup/auth 入口，所以單獨跑了對應測試檔案。

## Checklist

- [x] Bug fix
- [x] 本機跑過這個 PR 的程式碼
- [x] `git diff --check` 通過
- [x] staged diff 檢查過，沒有真實憑證 / IP / 網域 / PII
- [x] 不引入 breaking change
- [x] 同意按 MIT License 發布
- [x] 已讀 NOTICE / CODE_OF_CONDUCT.md
- [x] 這個 PR 不是為了協助任何針對未授權目標的使用
