### PR TITLE
docs(i18n): Chinese-canonical docs + bilingual README (fix broken #31 doc markdown)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,110 +1,107 @@
-# Code of Conduct
+# 行为准则
 
-## Our Commitment
+## 我们的承诺
 
-To make this project's community an open, welcoming, and constructive place, we commit that all participants
-(contributors, maintainers, issue submitters, PR authors, discussion participants) can interact in a
-harassment-free environment, regardless of age, body size, visible or invisible disability, ethnicity,
-gender identity, experience level, educational background, socioeconomic status, nationality, religion,
-sexual orientation, appearance, or personal choices.
+为了让本项目的社区成为一个开放、欢迎、有建设性的地方，我们承诺所有参与者
+（贡献者、维护者、issue 提交者、PR 作者、讨论参与者）都能在不受骚扰的环境
+里互动，无论年龄、体型、可见或不可见的残疾、族裔、性别认同、经验水平、教育
+背景、社会经济地位、国籍、宗教、性取向、外貌或个人选择。
 
-## Our Standards
+## 我们的标准
 
-The following behaviors are welcome:
+下面这些行为是欢迎的：
 
-- Respect different perspectives, experiences, and technical choices
-- Give and receive constructive feedback
-- Acknowledge mistakes, apologize to affected people, and learn from experience
-- Prioritize community interests over personal interests
-- Focus discussions on technical issues themselves, not on people
+- 尊重不同视角、经验、技术选择
+- 给和接受建设性反馈
+- 承认错误，向受影响的人道歉，从经验中学习
+- 把社区利益放在个人利益之上
+- 以技术问题本身为讨论焦点，不是人身
 
-The following behaviors are **not** acceptable:
+下面这些行为是**不**可接受的：
 
-- Sexual language, images, jokes, or advances
-- Derogatory comments, personal attacks, political attacks
-- Public or private harassment
-- Publishing others' personal information without permission (addresses, emails, phone numbers, etc.)
-- Any behavior reasonably considered unprofessional in a workplace environment
-- **Soliciting help for unauthorized testing** or **flaunting violations of ToS**
-  in issues / PRs / discussions
+- 性意味的语言、图像、玩笑、性挑逗
+- 嘲讽、人身攻击、政治攻击
+- 公开或私下的骚扰
+- 未经允许公布他人个人信息（住址、邮箱、电话等）
+- 任何在职场环境下被合理认为不专业的行为
+- 在 issue / PR / discussion 中**索取协助进行未授权测试**或**炫耀违反 ToS**
+  的行为
 
-## Project-Specific Additional Rules
+## 项目特定的额外规则
 
-This project is a security research tool. Community members **additionally** must comply with:
+本项目是个安全研究工具，社区成员**额外**需要遵守：
 
-1. Any behavior explicitly or implicitly indicating use of this tool against unauthorized targets
-   in issues / PRs / discussions will result in immediate closure and possible bans
-2. Any questions seeking specific strategies like "how to bypass OpenAI anti-fraud" or
-   "how to increase account survival rate to X%" will be redirected to [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md)
-   or directly closed
-3. For any "account top-up", "GPT mirror", "account resale" gray-market services built on this project,
-   maintainers reserve the right to refuse any related assistance
-4. Strict enforcement of anonymization standards in research materials like [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md) —
-   any PRs leaking real IPs / real domains / real accounts will be directly rejected
+1. 任何在 issue / PR / discussion 中明示或暗示自己在用本工具针对未授权目标
+   的行为，会被立即关闭并可能被封禁
+2. 任何索取"如何绕开 OpenAI 反欺诈"、"如何提高账号存活率到 X%"等具体策略
+   的提问，会被引导到 [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md)
+   或者直接关闭
+3. 任何以本项目为基础搭建的"代充值"、"GPT 镜像"、"账号转售"等灰产服务，
+   维护者保留拒绝任何相关协助的权利
+4. 在 [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md) 这类研究
+   材料的脱敏标准上严格执行 —— 任何泄漏真实 IP / 真实域名 / 真实账号的 PR
+   会被直接拒
 
-## Maintainer Responsibilities
+## 维护者职责
 
-Project maintainers are responsible for clearly communicating acceptable behavior standards and taking
-appropriate and fair corrective action against unacceptable behavior.
+项目维护者负责清晰说明可接受的行为标准，对任何不可接受的行为采取适当且
+公正的纠正措施。
 
-Maintainers have the right to:
+维护者有权：
 
-- Delete, edit, reject any comments, commits, code, issues, or other contributions that violate this code
-- Temporarily or permanently ban any individuals whose behavior is deemed inappropriate, threatening,
-  offensive, or harmful
+- 删除、编辑、拒绝任何不符合本准则的评论、commit、code、issue 等贡献
+- 临时或永久禁止任何认为不当、威胁、冒犯、有害的行为者
 
-## Scope
+## 适用范围
 
-This code of conduct applies to:
+本准则适用于：
 
-- All public spaces of this project (issues, PRs, discussions, wiki, commit messages)
-- Any public settings representing this project (speaking at conferences, citing this project
-  in blogs / papers)
+- 本项目所有公开空间（issue、PR、discussion、wiki、commit message）
+- 任何代表本项目的公开场合（在 conference 上发言、在博客 / 论文里引用本项
+  目时）
 
-## Reporting
+## 报告
 
-If you observe potential violations of this code, please report through GitHub Security Advisory (private channel).
+出现可能违反本准则的行为，请通过 GitHub Security Advisory（私密渠道）报告。
 
-All complaints will be reviewed and responded to as quickly and fairly as possible. Maintainers are
-obligated to respect the privacy and safety of the reporter.
+所有投诉会被尽快、公正地审查和回应。维护者有义务尊重报告人的隐私和安全。
 
-## Enforcement
+## 处置
 
-Maintainers will enforce violations according to the following process:
+维护者会按下面的流程处置违规：
 
-### 1. Reminder
+### 1. 提醒
 
-**Community Impact**: Use of unprofessional language or behavior not aligned with this code.
+**社区影响**：使用了不专业语言或不符合本准则的行为。
 
-**Result**: Private written warning clearly explaining the violation and its reason. May request
-a public apology.
+**结果**：私下书面警告，明确指出违规之处和原因。可能会要求公开道歉。
 
-### 2. Warning
+### 2. 警告
 
-**Community Impact**: Single or repeated violations.
+**社区影响**：单次或一系列违规行为。
 
-**Result**: Warning + prohibition from interacting with relevant parties for a period (including
-commenting, mentioning PRs / issues). Violations escalate to the next level.
+**结果**：警告 + 一段时间内不允许与相关人员互动（包括评论 / 标记 PR / issue
+等）。违反将进入下一级处置。
 
-### 3. Temporary Ban
+### 3. 临时封禁
 
-**Community Impact**: Serious violations, including repeated inappropriate behavior.
+**社区影响**：严重违规，包括持续的不当行为。
 
-**Result**: Prohibition from any form of participation in this project (comments, PRs, issues, etc.)
-for a specified period. Violations escalate to permanent ban.
+**结果**：在指定时间内禁止参与本项目的任何形式（评论、PR、issue 等）。违反
+将进入永久封禁。
 
-### 4. Permanent Ban
+### 4. 永久封禁
 
-**Community Impact**: Patterned serious violations, including repeated inappropriate behavior, harassment
-of individuals, attacks on / disparagement of groups.
+**社区影响**：模式化的严重违规，包括持续的不当行为、骚扰特定个体、对群体的
+攻击 / 贬低。
 
-**Result**: Permanent prohibition from any form of public interaction with this project.
+**结果**：永久禁止参与本项目的任何形式公开互动。
 
-## Attribution
+## 来源
 
-This code of conduct is adapted from [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html),
-with an added "Project-Specific Additional Rules" section to address this project's unique nature.
+本准则改编自 [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)，
+按本项目特殊性增加了"项目特定的额外规则"一节。
 
-The community impact levels are inspired by [Mozilla's enforcement ladder](https://github.com/mozilla/diversity).
+社区影响等级的定义灵感来自 [Mozilla 的执法阶梯](https://github.com/mozilla/diversity)。
 
-For more frequently asked questions about this code of conduct, see https://www.contributor-covenant.org/faq.
+更多关于本准则的常见问题，参见 https://www.contributor-covenant.org/faq。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,63 @@
-# Contribution Guide
+# 贡献指南
 
-Thanks for being willing to contribute. This is a research project where "useful" matters more than "perfectly compliant," but the following things will make your PR easier to merge.
+谢谢愿意贡献。这是个研究项目，"有用"比"完全合规则"更重要，但下面这些事能让你的 PR 更容易被合。
 
-> ⚠️ **IMPORTANT: Maintainers cannot manually reproduce your PR locally.**
+> ⚠️ **重要：维护者无法在本地手动复现你的 PR。**
 >
-> This means whether a PR gets merged depends **entirely on the quality of "working proof" you provide**. This isn't bureaucracy:
+> 这意味着 PR 能不能合，**完全取决于你提供的"跑通证据"够不够**。这不是形式主义：
 >
-> - **Solver problem type PR**: must include prompt text, `round_XX.json`, `checkcaptcha_pass_*.json`, pass rate statistics
-> - **Protocol adaptation PR**: must include packet capture comparison (before / after) + complete end-to-end pipeline logs
-> - **Daemon self-healing PR**: must include logs at the moment of trigger + logs of successful next round after recovery + `SQLite runtime_meta[daemon_state]` field diff
-> - **Bug fix / new feature**: must include reproduction command + failure logs before fix + success logs after fix
+> - **solver 题型的 PR**：必须附 prompt 文本、`round_XX.json`、`checkcaptcha_pass_*.json`、通过率统计
+> - **协议适配的 PR**：必须附抓包对比（before / after）+ 完整跑通到终态的 pipeline 日志
+> - **daemon 自愈的 PR**：必须附触发那一刻的日志 + 自愈后下一轮成功的日志 + `SQLite runtime_meta[daemon_state]` 字段差异
+> - **bug fix / new feature**：必须附复现命令 + 修复前失败日志 + 修复后成功日志
 >
-> See detailed requirements in [PR template](.github/PULL_REQUEST_TEMPLATE.md). Fill all "required" fields and check all "mandatory" checkboxes. **Missing evidence means the PR gets tagged `needs-info` and auto-closes after 14 days with no explanation.**
+> 详细要求看 [PR 模板](.github/PULL_REQUEST_TEMPLATE.md)，所有"必填"项都得填，所有"强制勾选"项都得勾。**证据缺了，PR 会被打 `needs-info` 标签，14 天没补全自动关闭，不解释。**
 
-## Wanted Contributions
+## 想要的贡献
 
-Roughly ordered by impact:
+按影响力大致排序：
 
-1. **New hCaptcha problem type solvers.** See a solver type not covered? Add it. Integration method in [`README.md`](README.md#加新题型) — three small functions + one dispatcher registration. If you have public prompt → label datasets, mention that in the PR
-2. **Protocol stage adaptation.** Stripe / PayPal / OpenAI have breaking changes roughly every few weeks. After patching and running stable a few times, submit a PR and add a line in `pipeline.py` changelog comment
-3. **Daemon self-healing loops.** Failure modes you've **actually** encountered, with failure logs attached—don't just speculate. Add detection + recovery + state flag cleanup
-4. **Reverse engineering notes.** Figured out new endpoints (new invitation mechanisms, new management API surfaces, etc.), want to add documentation to README research section? Welcome. Follow current style with obfuscation: RFC 5737 IPs, `*.example` domains
-5. **Translations / documentation polish.** Lots of inline comments still in Chinese; PRs translating to English are accepted, as long as behavior doesn't change
-6. **`flows/` test fixtures.** Real packet captures can't ship (contain cookies / PII), but obfuscated fixtures or tools for generating them are useful
+1. **新的 hCaptcha 题型 solver。** 见过 solver 没覆盖的题型就加上去。集成方式在 [`README.md`](README.md#加新题型) —— 三个小函数 + 一个 dispatcher 注册。如果你有公开的 prompt → label 数据集，那更好，PR 里说一下
+2. **协议阶段适配。** Stripe / PayPal / OpenAI 大概几周一次 breaking change。打了补丁、跑过几次稳了之后，提个 PR 顺手在 `pipeline.py` changelog 注释里加一行
+3. **Daemon 自愈环。** 你**真**遇到过的失败模式，附一段失败日志，别只是脑补。加上检测 + 恢复 + 状态标志清理
+4. **逆向笔记。** 逆出新端点（新邀请机制、新管理 API surface 之类），想把文档加到 README 研究段，欢迎。脱敏照现在的写法做：RFC 5737 IP、`*.example` 域名
+5. **翻译 / 文档润色。** 大量内联注释还是中文，翻成英文的 PR 接受，前提是不改行为
+6. **`flows/` 测试 fixture。** 真实抓包 ship 不了（含 cookies / PII），但脱敏过的 fixture 或者生成 fixture 的工具有用
 
-## Unwanted
+## 不想要的
 
-- "I ran this against $TARGET and got banned." Read [README empirical section](README.md#-反欺诈实证) — bans are expected, that's what we research
-- Requests to help run the toolset against unauthorized targets. Direct close, possible ban. See [`SECURITY.md`](SECURITY.md)
-- Refactor-only PRs with no new functionality. `card.py` is deliberately one 8000-line file; splitting it makes diffs harder to follow and doesn't reduce incidental complexity
-- Introducing new ML model dependencies without solid justification. The ML venv is already 4 GB
+- "我针对 $TARGET 跑了下被封了"。读一下 [README 实证段](README.md#-反欺诈实证) —— 被封是预期，研究的就是这个
+- 求帮忙针对未授权目标跑工具集。直接关，可能封禁。看 [`SECURITY.md`](SECURITY.md)
+- 只是 refactor、没加功能的 PR。`card.py` 故意做成 8000 行单文件，拆完之后 diff 更难追，incidental complexity 也没下降
+- 不带正当理由就引入新 ML 模型依赖。ML venv 已经 4 GB 了
 
-## Workflow
+## 工作流
 
-1. **Open an issue for bigger changes first.** 5 lines of discussion saves 500 lines of PR going the wrong way
-2. **Branch from `main`**, named `feat/<thing>` or `fix/<thing>`
-3. **Write human-readable commit messages.** Imperative mood, lowercase first letter, first line ≤72 characters, explanation in body if needed. Look at `git log --oneline | head` and follow the style
-4. **Test if you can.** The project heavily depends on online services; coverage isn't required, but simulate with offline-mock or local-mock (`config.local-mock.json`) where possible
-5. **Sanitize diffs before committing.** `.gitignore` already excludes `output/` / `flows/` / `paypal_cf_persist/` / runtime configs, but do `git diff --cached` once to ensure no real cookies / tokens / IPs / emails sneak into staging
-6. **PR title** follows commit format. Description answers three things: what changed, why, how you tested
+1. **改东西大一点先开 issue。** 5 行讨论能省 500 行走错方向的 PR
+2. **从 `main` 拉分支**，命名 `feat/<thing>` 或 `fix/<thing>`
+3. **commit message 写人话。** 命令式语气、首字母小写、首行 ≤72 字符、需要解释就写正文。看 `git log --oneline | head` 跟着风格走
+4. **能测就测。** 项目重度依赖在线服务，不强制覆盖率，但能用 offline-mock 或 local-mock（`config.local-mock.json`）模拟的就模拟
+5. **提交前对 diff 做一次脱敏。** `.gitignore` 已经排了 `output/` / `flows/` / `paypal_cf_persist/` / 运行时配置之类，但 `git diff --cached` 看一眼，确认没有真实 cookie / token / IP / 邮箱混进 stage
+6. **PR 标题** 跟 commit 同格式。描述回答三件事：改了什么、为什么、怎么测的
 
-## Code Style
+## 代码风格
 
-- Python: basically PEP-8, 4-space indent, no hard line length, no mandatory auto-formatter (existing code has its own rhythm; match locally)
-- Comments: Chinese or English both fine. Use English for new code expected to be read by non-Chinese speakers
-- Logging: provide enough context to see the problem from `tail`. Current pattern: `[STAGE] something something detail=...`
-- Config: prefer adding flags to existing JSON sections over creating new top-level ones. Document user-visible flags in `README.md`
+- Python：基本 PEP-8，4 空格缩进，不强制行长，不强制 auto-formatter（现有代码有自己的节奏，本地匹配就行）
+- 注释：中英文都行。预计会被非中文读者读到的新代码用英文更友好
+- 日志：留够上下文，能从 `tail` 上看出问题。现在的 pattern：`[STAGE] something something detail=...`
+- 配置：优先在已有 JSON section 里加 flag，少新建顶级 section。用户能看见的 flag 在 `README.md` 文档化
 
-## Sanitization Checklist for Research Content Contributions
+## 研究内容贡献的脱敏清单
 
-Adding to [empirical section](README.md#-反欺诈实证):
+要给 [实证段](README.md#-反欺诈实证) 加内容：
 
-- IPs: use `203.0.113.x` (TEST-NET-3), `198.51.100.x` (TEST-NET-2), `192.0.2.x` (TEST-NET-1). **Never** post real IPs, even if only temporarily used
-- Domains: use `*.example`, `*.example.com`, `*.test`, `*.invalid`. **Never** post real domains
-- Emails: `you@example.com`, `tester@example.com`
-- Account counts and times: **keep accurate**, that's the research itself
-- Internal ASNs / org names: replace with `AS-XX`, `ISP-A`
-- ChatGPT account IDs / tokens / cookies: **never** post, truncation doesn't help
+- IP：用 `203.0.113.x`（TEST-NET-3）、`198.51.100.x`（TEST-NET-2）、`192.0.2.x`（TEST-NET-1）。**永远别**发真实 IP，哪怕只是短暂用过的
+- 域名：用 `*.example`、`*.example.com`、`*.test`、`*.invalid`。**永远别**发真实域名
+- 邮箱：`you@example.com`、`tester@example.com`
+- 账号数和时间：**保持真实**，那是研究本身
+- 内部 ASN / 组织名：替成 `AS-XX`、`ISP-A`
+- ChatGPT 账号 ID / token / cookie：**永远别**发，截断都不行
 
-## Questions
+## 问题
 
-Open a discussion or issue. No chat, Discord, or mailing list.
+开 discussion 或 issue。没有 chat、没有 Discord、没有 mailing list。

--- a/CTF-pay/README.md
+++ b/CTF-pay/README.md
@@ -1,42 +1,40 @@
-# CTF Scenario Current Protocol Main Chain
-
-Based on real packet captures, organized as follows:
+CTF 场景下当前协议主链，按真实抓包整理如下：
 
 - `init`
 - `elements/sessions`
 - `consumers/sessions/lookup`
-- `payment_pages/<session>` address / tax_region update
+- `payment_pages/<session>` 地址 / tax_region 更新
 - `confirm`
-  - Prioritize `inline_payment_method_data`
-  - Compatible with `shared_payment_method`
+  - 优先走 `inline_payment_method_data`
+  - 兼容 `shared_payment_method`
 - `3ds2/authenticate`
 - `poll`
 
-## Several Easy-to-Misinterpret Points:
+几个容易误判的点：
 
-- `setatt_` / `source` having values only means 3DS authenticate source was obtained, not that it succeeded.
-- `state = challenge_required` and `ares.transStatus = C` means **browser side needs to continue completing the challenge**, not a "dead card".
-- Only after the browser truly completes the challenge will the intent / setup_intent status continue to advance.
+- `setatt_` / `source` 有值，只代表拿到了 3DS authenticate 的 source，不代表已经成功。
+- `state = challenge_required` 且 `ares.transStatus = C`，表示 **需要浏览器侧继续完成 challenge**，不是“废卡”。
+- 只有浏览器把 challenge 真正做完，后面的 intent / setup_intent 状态才会继续推进。
 
-## Current Script Behavior:
+当前脚本行为：
 
-- Will record in `three_ds_result`:
+- 会在 `three_ds_result` 里记录：
   - `state`
   - `trans_status`
   - `source`
   - `acs_url`
   - `creq`
   - `three_ds_server_trans_id`
-- If entering `challenge_required`, the script will pause here, waiting for subsequent browser-side challenge.
+- 如果进入 `challenge_required`，脚本会停在这里，等待后续浏览器侧 challenge。
 
-## Challenge Debugging in Headless Environment:
+无图形环境下的 challenge 调试：
 
-- `card.py` now writes the latest bridge info to `/tmp/stripe_hcaptcha_bridge_latest.json`
-- If the machine has no `DISPLAY`, `card.py` no longer crashes directly; can fall back to headless Playwright or only output bridge URL
-- Local helper provided: `CTF-pay/hcaptcha_bridge_helper.py`
-  - Usage:
+- `card.py` 现在会把最新 bridge 信息写到 `/tmp/stripe_hcaptcha_bridge_latest.json`
+- 如果机器没有 `DISPLAY`，`card.py` 不再直接崩；可回退为 headless Playwright 或只输出 bridge URL
+- 已提供本地 helper：`CTF-pay/hcaptcha_bridge_helper.py`
+  - 用法：
     - `python hcaptcha_bridge_helper.py http://127.0.0.1:PORT/index.html`
-  - Common commands:
+  - 常用命令：
     - `TEXT`
     - `SHOT /tmp/bridge.png`
     - `CHSHOT /tmp/challenge.png`
@@ -44,40 +42,40 @@ Based on real packet captures, organized as follows:
     - `VERIFY`
     - `STATE`
 
-## Most Relevant Fields in `config.auto.json`:
+`config.auto.json` 中和运行时最相关的字段：
 
 - `runtime.confirm_mode`
-  - `inline_payment_method_data`: Closer to current real frontend flow
-  - `shared_payment_method`: Compatible with older flow of creating `payment_method` then confirming
+  - `inline_payment_method_data`：更贴近当前真实前端链路
+  - `shared_payment_method`：兼容旧的先建 `payment_method` 再 confirm
 - `runtime.version`
 - `runtime.js_checksum`
 - `runtime.rv_timestamp`
 
-**Note:**
+注意：
 
-- `runtime.js_checksum` and `runtime.rv_timestamp` must align with current checkout runtime.
-- `top_checkout_config_id` / `payment_method_checkout_config_id` can be left empty; script will auto-fill from current session context.
-- Default `load_config()` prioritizes reading the passed path; if not found, automatically falls back to `CTF-pay/config.auto.json`.
+- `runtime.js_checksum` 与 `runtime.rv_timestamp` 必须和当前 checkout runtime 对齐。
+- `top_checkout_config_id` / `payment_method_checkout_config_id` 可以先留空，脚本会用当前会话上下文回填。
+- 默认 `load_config()` 会优先读传入路径；如果没找到，会自动回退到 `CTF-pay/config.auto.json`。
 
-## Fresh Checkout Auto-Generation
+## fresh checkout 自动生成
 
-`card.py` now supports regenerating a new checkout from ChatGPT side before session expires:
+现在 `card.py` 支持在 session 失活前，先从 ChatGPT 侧重新生成新的 checkout：
 
-- Commands:
+- 命令：
   - `python card.py fresh --fresh-only`
   - `python card.py auto`
   - `python card.py --fresh`
-  - Or directly use preset scheme 1 config:
+  - 也可直接用预置方案1配置：
     - `python card.py auto --config config.auto-register.json`
-- **ABCard / access_token mode recommended by default**, no longer relies on extracting login state from `flows`:
+- 默认推荐 **ABCard / access_token 模式**，不再依赖从 `flows` 提取登录态：
   - `Authorization: Bearer <access_token>`
-  - Optional `__Secure-next-auth.session-token`
-  - Optional `oai-device-id`
-  - First call `GET /api/auth/session` to refresh / validate access token
-  - Then sequentially try ABCard compatible flow:
+  - 可选 `__Secure-next-auth.session-token`
+  - 可选 `oai-device-id`
+  - 先调 `GET /api/auth/session` 刷新 / 校验 access token
+  - 再按 ABCard 兼容链路依次尝试：
     - `POST /backend-api/payments/checkout`
     - `POST /backend-api/subscriptions/checkout`
-- ABCard style payload:
+- ABCard 风格 payload：
   - `plan_type`
   - `payment_lower_bound_amount_cents`
   - `payment_upper_bound_amount_cents`
@@ -86,103 +84,132 @@ Based on real packet captures, organized as follows:
   - `workspace_name`
   - `seat_quantity`
   - `promo_campaign_id`
-- `flows` now serves only as **optional template source**:
-  - When `request_style=modern` or explicitly enabling `use_flows_for_templates`
-  - Will only read sentinel/body templates in `../flows`
-- `config.auto.json` added new `fresh_checkout` section:
-  - Defaults:
+- `flows` 现在只作为 **可选模板来源**：
+  - 当 `request_style=modern` 或显式启用 `use_flows_for_templates` 时
+  - 才会去读取 `../flows` 里的 sentinel/body 模板
+- `config.auto.json` 已新增 `fresh_checkout` 段：
+  - 默认：
     - `fresh_checkout.auth.mode = "access_token"`
     - `fresh_checkout.request_style = "abcard"`
     - `fresh_checkout.bootstrap_from_flows = false`
-  - Main fields to fill:
+  - 主要填写：
     - `fresh_checkout.auth.access_token`
-    - `fresh_checkout.auth.session_token` (optional but recommended; script can auto-refresh access token)
-    - `fresh_checkout.auth.device_id` / `oai_device_id` (optional)
+    - `fresh_checkout.auth.session_token`（可选，但推荐；脚本可自动刷新 access token）
+    - `fresh_checkout.auth.device_id` / `oai_device_id`（可选）
     - `fresh_checkout.plan.plan_name`
     - `fresh_checkout.plan.promo_campaign_id`
-  - Scheme 1 (recommended closed-loop):
+  - 方案1（推荐闭环）：
     - `fresh_checkout.auth.auto_register.enabled = true`
     - `fresh_checkout.auth.auto_register.project_dir = "./CTF-reg"`
     - `fresh_checkout.auth.auto_register.config_path = "./CTF-reg/config.example.json"`
-    - `CTF-reg` is the built-in registration flow code directory in this repo, no longer depends on external project paths
-    - If `mode = "auto_register"`, script will first call local registration flow to get `access_token / session_token / device_id`, then generate fresh checkout
-    - If keeping `mode = "access_token"` but enabling `auto_register.enabled = true`, when existing token expires / becomes invalid / account is deactivated, will also auto-register new account and retry
-  - When `auto_refresh_on_inactive: true`, if Stripe returns `checkout_not_active_session`, script will auto-generate fresh checkout and continue
-  - If you need to stabilize discount checkout, recommend also enabling:
+    - `CTF-reg` 是本仓库内置的注册流程代码目录，不再依赖外部项目路径
+    - 如果 `mode = "auto_register"`，脚本会先调用本地注册流程拿到
+      `access_token / session_token / device_id`，再生成 fresh checkout
+    - 如果保留 `mode = "access_token"`，但开启了 `auto_register.enabled = true`，
+      当现有 token 过期 / 失效 / 账号停用时，也会自动注册新号后重试
+  - `auto_refresh_on_inactive: true` 时，如果 Stripe 返回 `checkout_not_active_session`，脚本会先自动生成 fresh checkout 再继续
+  - 如果你需要把优惠 checkout 跑稳，建议再开启：
     - `fresh_checkout.check_coupon_after_checkout = true`
-      - After creating checkout, additionally call `GET /backend-api/promo_campaign/check_coupon`
-      - Only for observing `eligible / not_eligible`, **not** treated as actual redeem flow
+      - 创建 checkout 后补打一遍
+        `GET /backend-api/promo_campaign/check_coupon`
+      - 仅用于观测 `eligible / not_eligible`，**不**把它当成真正的 redeem 流程
     - `fresh_checkout.expected_due = 0`
-      - Don't check ChatGPT checkout preview, instead use Stripe `init.total_summary.due` as truth for validating discount hit
+      - 不看 ChatGPT checkout preview，而是以 Stripe `init.total_summary.due`
+        为准校验是否命中优惠
     - `fresh_checkout.auto_refresh_on_due_mismatch = true`
-      - If fresh checkout created successfully but Stripe `due` is not expected amount, script will auto-regenerate fresh checkout and retry
+      - 如果 fresh checkout 创建成功，但 Stripe `due` 不是预期金额，
+        脚本会自动重新生成 fresh checkout 再试
     - `fresh_checkout.max_due_mismatch_refreshes = 3`
-      - Controls max number of refreshes on amount mismatch
+      - 控制金额不匹配时最多重刷几次
   - `pre_solve_passive_captcha = true`
-    - More aligned with real `flows`: get `passive_captcha_token` before confirming
-    - In historical `due=0` flow, confirm request included `passive_captcha_token`
+    - 更贴近真实 `flows`：confirm 前先拿 `passive_captcha_token`
+    - 历史 `due=0` 流里，confirm 请求里是带了 `passive_captcha_token` 的
   - `browser_challenge.use_for_passive_captcha = true`
-    - Will prioritize trying local headless browser to execute Stripe invisible hCaptcha, maximizing getting passive token closer to real frontend
-    - If browser approach doesn't get token, falls back to captcha service
+    - 会优先尝试用本地 headless 浏览器执行 Stripe invisible hCaptcha，
+      尽量拿到和真实前端更接近的 passive token
+    - 如果浏览器方案没拿到 token，再回退到打码平台
   - `browser_challenge.passive_headless = true`
-    - Can run passive captcha browser flow even in headless environments without DISPLAY
+    - 在无 DISPLAY 的环境里也能跑 passive captcha 浏览器链路
   - `browser_challenge.passive_timeout_ms = 45000`
-    - Controls browser wait duration for invisible/passive captcha
+    - 控制 invisible/passive captcha 的浏览器等待时长
 
-**Note:**
+注意：
 
-- If `/api/auth/session` still returns user info, but checkout returns:
-  - `401[token_invalidated]`: Current access_token / session_token login state revoked;
-  - `401[account_deactivated]`: Current account itself deactivated;
-  - Both cases are not Stripe protocol issues, but ChatGPT side credential / account status issues.
+- 如果 `/api/auth/session` 还能返回用户信息，但 checkout 返回：
+  - `401[token_invalidated]`：当前 access_token / session_token 登录态已被撤销；
+  - `401[account_deactivated]`：当前账号本身已被停用；
+  - 这两种情况都不是 Stripe 协议问题，而是 ChatGPT 侧凭证 / 账号状态问题。
 
-## Pure Local CTF Mock Gateway
+## 纯本地 CTF mock gateway
 
-If current target is to further solidify **local challenge / 3DS state machine** without relying on any external network, directly use:
+如果当前目标是继续压实 **本地 challenge / 3DS 状态机**，而不希望依赖任何外部网络，可直接使用：
 
 - `python card.py auto --config config.local-mock.json --local-mock`
 
-Behavior:
+行为：
 
-- Auto rebuild fresh checkout parameters from local `flows`;
-- Start a local HTTP mock gateway on `127.0.0.1`;
-- `card.py` initiates real HTTP requests to local gateway, replaying:
+- 自动从本地 `flows` 重建 fresh checkout 参数；
+- 在 `127.0.0.1` 启动一个本地 HTTP mock gateway；
+- 由 `card.py` 对本地 gateway 发起真实 HTTP 请求，回放：
   - `fresh checkout`
   - `confirm`
   - `verify_challenge`
   - `3ds2/authenticate`
   - `poll`
 
-Default scenario:
+默认场景：
 
 - `challenge_pass_then_decline`
-  - Local mock `network_checkcaptcha(pass=true)`
+  - 本地模拟 `network_checkcaptcha(pass=true)`
   - `verify_challenge -> requires_action`
   - `3DS2 -> succeeded`
-  - Finally `card_declined`
+  - 最终 `card_declined`
 
-Also supports:
+也支持：
 
 - `challenge_failed`
 - `no_3ds_card_declined`
 
-Replay artifacts written to by default:
+回放工件默认写到：
 
 - `/tmp/ctf_local_mock_latest.json`
 
-## GoPay WhatsApp OTP Auto-Receive
+## GoPay WhatsApp OTP 自动接收
 
-GoPay linking sends OTP to WhatsApp. Old flow only supported CLI / WebUI manual input; now `gopay.py` supports auto-receiving from WebUI WhatsApp login sidecar, local HTTP relay, state/log file or command.
+GoPay linking 会把 OTP 发到 WhatsApp。旧流程只支持 CLI / WebUI 手动输入；
+现在 `gopay.py` 支持自动从 WebUI WhatsApp 登录 sidecar、本地 HTTP relay、
+state/log 文件或命令取码。
 
-### 1. WebUI Recommended Path: Only Expose One WhatsApp Login Entry
+### 1. WebUI 推荐路径：只暴露一个 WhatsApp 登录入口
 
-WebUI GoPay config page shows only one entry:```text
-WhatsApp Login / QR Code Scanning to Receive GoPay OTP
-```Click to enter `/whatsapp`, then scan the QR code to log in to WhatsApp. On the login page, you can freely choose between the `baileys` or `wwebjs` engine: Baileys (`@whiskeysockets/baileys`) is recommended by default, which directly listens to the WhatsApp multi-device socket. If you need to fall back to the legacy `whatsapp-web.js`/Chromium path, simply select `whatsapp-web.js` from the dropdown on the page and restart the sidecar. `WEBUI_WA_ENGINE=wwebjs` can still be used as the default value on first startup. The sidecar will listen for new messages, extract GoPay OTP, and write to:```text
+WebUI GoPay 配置页只显示一个入口：
+
+```text
+WhatsApp 登录 / 扫码接收 GoPay OTP
+```
+
+点击后进入 `/whatsapp`，扫码登录 WhatsApp。登录页可以自由选择
+`baileys` 或 `wwebjs` 引擎：默认推荐 Baileys（`@whiskeysockets/baileys`）
+直接监听 WhatsApp multi-device socket；如需回退到旧的
+`whatsapp-web.js`/Chromium 路径，在页面下拉选择 `whatsapp-web.js`
+并重启 sidecar 即可。`WEBUI_WA_ENGINE=wwebjs` 仍可作为首次启动默认值。
+sidecar 会监听新消息，提取 GoPay OTP，并写入：
+
+```text
 SQLite runtime_meta[wa_state] / HTTP relay
-```Note: The GoPay/WhatsApp OTP template is sometimes marked as a sensitive message by WhatsApp. Linked devices (WhatsApp Web) can only see placeholder hints like "You received a one-time password, which can only be viewed on the primary device", and cannot retrieve the OTP message content. This is not a regex parsing issue, but rather WhatsApp Web not delivering the OTP message content. The WebUI runner will automatically pop up a GoPay OTP fallback input box when `[gopay] waiting WhatsApp OTP from file: ...` appears in the payment log; after entering the verification code seen on the mobile primary device, it will be written to the same `SQLite runtime_meta[wa_state] / HTTP relay`, and the payment process continues.
+```
 
-When exporting the GoPay configuration via WebUI, it will automatically write:```json
+注意：GoPay/WhatsApp 的 OTP 模板有时会被 WhatsApp 标记为敏感消息，
+linked device（WhatsApp Web）只能看到类似“你收到了一次性密码，只能在主要
+设备上查看”的占位提示，拿不到验证码正文。这不是解析正则问题，而是
+WhatsApp Web 不下发 OTP 正文。WebUI runner 会在支付日志出现
+`[gopay] waiting WhatsApp OTP from file: ...` 时自动弹出 GoPay OTP 兜底
+输入框；把手机主设备上看到的验证码填进去后，会写入同一个
+`SQLite runtime_meta[wa_state] / HTTP relay`，支付流程继续。
+
+WebUI 导出 GoPay 配置时会自动写入：
+
+```json
 {
   "gopay": {
     "otp": {
@@ -193,35 +220,54 @@ When exporting the GoPay configuration via WebUI, it will automatically write:``
     }
   }
 }
-```sidecar dependency in `webui/whatsapp_relay/`:```bash
+```
+
+sidecar 依赖在 `webui/whatsapp_relay/`：
+
+```bash
 cd webui/whatsapp_relay
 npm install
-```Current dependencies include:
+```
 
-- `@whiskeysockets/baileys`: default engine;
-- `whatsapp-web.js`: fallback engine.
+当前依赖包含：
 
-### 2. Optional: Standalone HTTP relay
+- `@whiskeysockets/baileys`：默认引擎；
+- `whatsapp-web.js`：备用引擎。
 
-The repository includes a minimal HTTP relay that only receives WhatsApp webhooks / notification forwarding content under your own control, extracts the 6-digit OTP, writes it to `SQLite runtime_meta[wa_state]`, and exposes `/latest` for the payment flow to poll:```bash
+### 2. 可选：独立 HTTP relay
+
+仓库内置一个很小的 HTTP relay，只负责接收你自己控制的 WhatsApp webhook /
+通知转发内容，提取 6 位 OTP，写入 `SQLite runtime_meta[wa_state]`，并暴露 `/latest`
+给支付流程轮询：
+
+```bash
 python CTF-pay/whatsapp_otp_relay.py --port 8765
-```# Local Quick Self-Testing:```bash
+```
+
+本地快速自测：
+
+```bash
 curl -X POST http://127.0.0.1:8765/ingest \
   -H 'Content-Type: application/json' \
   -d '{"from":"gopay","text":"Kode verifikasi GoPay Anda adalah 123456"}'
 
 curl http://127.0.0.1:8765/latest
-````/webhook` is compatible with common Meta WhatsApp Cloud API webhook formats:
+```
+
+`/webhook` 兼容 Meta WhatsApp Cloud API 常见 webhook 形态：
 
 - `GET /webhook?hub.mode=subscribe&hub.verify_token=...&hub.challenge=...`
-  Used for webhook verification;
-- `POST /webhook` receives messages from `entry[].changes[].value.messages[]`.
+  用于 webhook 校验；
+- `POST /webhook` 接收 `entry[].changes[].value.messages[]` 消息。
 
-If you use Android notification forwarding, already have a WhatsApp Web bridge, or other self-built relay, you can simply POST message text to `/ingest`, or provide your own `/latest` endpoint that returns the latest OTP.
+如果你用 Android 通知转发、已有 WhatsApp Web bridge 或其他自建 relay，只要把
+消息文本 POST 到 `/ingest`，或自己提供一个返回最新 OTP 的 `/latest` 接口即可。
 
-### 3. Manual configuration of `gopay.otp`
+### 3. 手动配置 `gopay.otp`
 
-See example in `CTF-pay/config.gopay.example.json`:```json
+示例见 `CTF-pay/config.gopay.example.json`：
+
+```json
 {
   "gopay": {
     "country_code": "62",
@@ -237,7 +283,11 @@ See example in `CTF-pay/config.gopay.example.json`:```json
     }
   }
 }
-```Also supports file polling:```json
+```
+
+也支持文件轮询：
+
+```json
 {
   "gopay": {
     "otp": {
@@ -248,7 +298,11 @@ See example in `CTF-pay/config.gopay.example.json`:```json
     }
   }
 }
-```HTTP relay polling:```json
+```
+
+HTTP relay 轮询：
+
+```json
 {
   "gopay": {
     "otp": {
@@ -259,7 +313,11 @@ See example in `CTF-pay/config.gopay.example.json`:```json
     }
   }
 }
-```Or command polling:```json
+```
+
+或命令轮询：
+
+```json
 {
   "gopay": {
     "otp": {
@@ -270,10 +328,20 @@ See example in `CTF-pay/config.gopay.example.json`:```json
     }
   }
 }
-```### 4. Running
+```
 
-CLI / pipeline will prioritize using `gopay.otp` as long as `--gopay-otp-file` is not passed:```bash
+### 4. 运行
+
+CLI / pipeline 只要不传 `--gopay-otp-file`，就会优先使用 `gopay.otp`：
+
+```bash
 python CTF-pay/gopay.py --config CTF-pay/config.gopay.example.json
 python CTF-pay/card.py auto --config CTF-pay/config.paypal.json --gopay
 python pipeline.py --config CTF-pay/config.paypal.json --gopay
-```In WebUI mode, if the configuration contains a non-manual `gopay.otp`, the runner will skip the old `--gopay-otp-file` manual popup and let `gopay.py` directly poll the automatic OTP provider. If the automatic provider is waiting for a file path, the runner will also recognize the wait log and open the same manual fallback popup to handle WhatsApp Web's "primary device visible" placeholder message. If `gopay.otp` is not configured, the behavior remains unchanged: a manual input popup appears on the run page for WhatsApp OTP.
+```
+
+WebUI 模式下，如果配置里存在非手动 `gopay.otp`，runner 会跳过旧的
+`--gopay-otp-file` 手动弹窗，让 `gopay.py` 直接轮询自动 OTP provider。
+如果自动 provider 等待的是文件路径，runner 也会识别等待日志并打开同一个
+手动兜底弹窗，用于处理 WhatsApp Web “主要设备可见”占位消息。如果没有配置
+`gopay.otp`，行为保持不变：运行页弹窗手动输入 WhatsApp OTP。

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,355 @@
+> [简体中文](README.md) | **English**
+
+<p align="center">
+  <img src="docs/images/logo-light.png#gh-light-mode-only" width="120" alt="Gpt-Agreement-Payment logo">
+  <img src="docs/images/logo-dark.png#gh-dark-mode-only"   width="120" alt="Gpt-Agreement-Payment logo">
+</p>
+
+# Gpt-Agreement-Payment
+
+End-to-end replay tool for ChatGPT Plus / Team subscription agreements: reverse-engineered from packet capture the entire chain `Stripe Checkout → PayPal / GoPay / QRIS → ChatGPT manual-approval → Codex OAuth + PKCE` and implemented as a runnable client. Includes a from-scratch hCaptcha visual solver, PayPal fraud detection early-exit branch, and a set of empirical anti-fraud mechanism data collected from real execution.
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
+[![CI](https://img.shields.io/github/actions/workflow/status/DanOps-1/Gpt-Agreement-Payment/ci.yml?label=CI)](https://github.com/DanOps-1/Gpt-Agreement-Payment/actions)
+[![Use](https://img.shields.io/badge/use-CTF%20%2F%20bug%20bounty-red)](#legal-boundary)
+
+---
+
+## Public Benefit API Relay Station
+
+| Logo | Name | Description | Website |
+| --- | --- | --- | --- |
+| <a href="https://api.lukyface.com/" target="_blank"><img src="docs/images/sponsors/lukyface.png" alt="lukyface API" width="140" /></a> | lukyface API (Author-run · Public Benefit Station) | Unified AI model aggregation / distribution gateway (based on new-api), OpenAI / Claude / Gemini protocol interconversion, self-use surplus sharing. **Pure public benefit, non-profit**.<br><br>**Open only to [LINUX DO](https://linux.do/) users** · **Payment in LDC (Linux Do in-site currency) only** · Public benefit station exchange group: **`1107410931`** | [https://api.lukyface.com/](https://api.lukyface.com/) |
+
+---
+
+> [!CAUTION]
+> **Using this project constitutes acceptance of all terms in [`NOTICE`](NOTICE).** The project is provided AS IS, with no warranties, and the maintainers assume no responsibility. Authorized use only on systems you own / legitimate CTF / authorized bug bounty in-scope assets / security research. **Strictly prohibited** for fraud, payment evasion, bulk account creation for resale, violation of third-party ToS, unauthorized targets. All legal responsibility rests with the user. If you do not accept these terms, **do not use**.
+
+---
+
+## What This Is
+
+Supports four subscription activation paths:
+
+| Path | Entry Point | Use Case |
+|---|---|---|
+| **Team / Plus (PayPal billing agreement)** | `pipeline.py --paypal` | Stripe Checkout → PayPal billing agreement → ChatGPT manual approval |
+| **Plus (promo long link + PayPal agreement auth)** | `scripts/no_card_paypal_plus.py` | OpenAI official promo campaign long link + PayPal guest checkout completing billing agreement protocol |
+| **Plus / Team (GoPay Indonesia)** | `pipeline.py --gopay` | Midtrans linking + GoPay wallet binding, IDR region exclusive |
+| **Plus / Team (QRIS scan)** | `pipeline.py --qris` | Midtrans QRIS, remote preview + reference polling settlement |
+
+Given a clean proxy + payment credential, run the command to completion and get the OAuth `refresh_token`.
+
+Four points worth examining:
+
+- **N-worker concurrency + phone-lock OTP critical section mutual exclusion** (`webui/backend/parallel_runner.py`). Same phone across multiple workers serializes OTP phase using advisory lock, pre/post-OTP fully parallelized; DB atomic claim + placeholder INSERT prevents multiple workers contending for same promo_link / same inventory email. Frontend configures phone pool (M rows) + concurrency N (can exceed M), worker maps to phone pool via `i % M` round-robin.
+- **hCaptcha visual solver** (`CTF-pay/hcaptcha_auto_solver.py`, ~4000 lines, independently usable). VLM primary path + CLIP/OpenCV heuristic fallback + Playwright human action synthesis, covers 12 known hCaptcha question types.
+- **Anti-fraud mechanism empirical data**. IP string-level exact fingerprinting, batch correlation delayed banning, probe layer vs ban layer separation. Measured sample of ~2% 24-hour survival rate across 45 accounts, including corrected models. See [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md).
+- **Twelve-path self-healing daemon loops** (`pipeline.py::daemon()`). Webshare API auto IP rotation (webshare jitter fallback to `/tmp/gost_last.json` cache), CF DNS quota cleanup, tmpfs orphan recovery, gost relay watchdog, DataDome slider auto-drag. Design goal is unattended operation for weeks.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A[pipeline.py / webui] --> B[CTF-reg/<br/>browser_register.py<br/>Camoufox + Turnstile]
+    B --> C[CTF-pay/card.py<br/>Stripe Checkout replay]
+    C --> D{Payment path}
+    D -->|paypal| E1[Camoufox / Node RPA<br/>PayPal billing agreement]
+    D -->|gopay| E2[Midtrans linking<br/>+ WhatsApp OTP]
+    D -->|qris| E3[QRIS QR<br/>+ remote preview]
+    E1 --> F[Stripe poll<br/>state=succeeded]
+    E2 --> F
+    E3 --> F
+    F --> G[Camoufox second login<br/>Codex OAuth + PKCE]
+    G --> H[refresh_token<br/>output/webui.db &#40;SQLite&#41;]
+```
+
+For detailed subsystem decomposition, file organization, and protocol chain details, see [`docs/architecture.md`](docs/architecture.md).
+
+---
+
+## Current Status and Entry Barriers
+
+To be frank, this is not an out-of-the-box tool. Running through the entire pipeline requires at least:
+
+- A real, login-capable PayPal account (or go through PayPal guest checkout authorization flow)
+- A proxy with exit in EU / US / ID (region locked based on selected payment path)
+- A Cloudflare zone (optional, for enabling catch-all subdomain email registration; also supports Outlook code pool)
+- A Linux machine capable of running Camoufox + Playwright (approximately 5 GB disk + 2 GB memory)
+- (Required for PayPal guest checkout) An SMS code gateway API key for PayPal signup
+- (Required for GoPay) A WhatsApp online number + WhatsApp code verification service
+- (Optional) An OpenAI-compatible VLM API key for hCaptcha solving; residential / pseudo-residential exits typically don't trigger hCaptcha, and CLIP degradation is available without VLM
+- (Optional) A captcha solving platform API key compatible with createTask/getTaskResult protocol as a fallback for browser passive captcha
+
+Full end-to-end setup typically takes 1–3 hours for initial configuration tuning. Once daemon mode runs stably, a single pipeline takes ~5 minutes; concurrent mode with 2 workers on the same phone generates 2 accounts in ~3 minutes.
+
+Code is research-oriented, organized by protocol stage, and doesn't prioritize maximum readability.
+
+---
+
+## Getting Started
+
+### Beginner Path: WebUI Configuration Wizard (Recommended)
+
+Compress 1–3 hours of manual configuration into ~15 minutes. 14-step wizard + real-time preflight self-checks + built-in runtime controller (SSE log stream + concurrency panel) generate `CTF-pay/config.auto.json` + `CTF-reg/config.paypal-proxy.json` configurations.
+
+![WebUI screenshot](docs/images/webui.png)
+
+#### Docker Deployment (Fastest Path, One-Click Start)
+
+The repo comes with `Dockerfile` (multi-stage build: Node frontend + Ubuntu 24.04 runtime) + `docker-compose.yml`, packing all system dependencies / Playwright Chromium+Firefox / Camoufox / gost SOCKS5 relay / Node QuickJS (for OpenAI Sentinel) into the image. The git working tree on the host serves as the single source of truth, bind-mounted into the container; restart with `docker compose restart` for instant effect after modifying Python code, no rebuild needed.
+
+```bash
+git clone https://github.com/DanOps-1/Gpt-Agreement-Payment
+cd Gpt-Agreement-Payment
+docker compose up -d --build
+# Default listening on 127.0.0.1:8765 (host port), open http://127.0.0.1:8765/ in browser
+# First visit redirects to /setup to create admin
+```
+
+Common Maintenance Commands:
+
+```bash
+# Real-time logs
+docker compose logs -f webui
+
+# Debug inside container (pip list / run tests / inspect SQLite)
+docker compose exec webui bash
+
+# Reload uvicorn after Python code changes (bind mount already syncs source code, just restart process)
+docker compose restart webui
+
+# Rebuild dist in container after frontend code changes
+docker compose exec webui sh -c "cd /app/webui/frontend && npm run build"
+
+# Completely stop + clean containers
+docker compose down
+
+# Image upgrade (pull new base / upgrade Python packages)
+docker compose build --no-cache && docker compose up -d
+```
+
+# Data Persistence
+
+The `output/` directory is a host directory bind mount containing `webui.db` (SQLite) + run results / logs visible and backupable to the host. `webui/frontend/dist` and `node_modules` use anonymous volumes, which are overridden by the baked image version (not overridden by an empty host directory).
+
+## Public Access (nginx Reverse Proxy + HTTPS)
+
+See [`webui/README.md`](webui/README.md). By default, `docker-compose.yml` binds the port to `127.0.0.1:8765`; to expose directly to `0.0.0.0`, modify the `ports` section (not recommended without an authentication layer in front).
+
+#### Manual Installation (without Docker)
+
+```bash
+# 1. Backend dependencies
+pip install -r webui/requirements.txt
+
+# 2. Frontend build (one-time)
+cd webui/frontend && pnpm i && pnpm build && cd ../..
+
+# 3. Start
+python -m webui.server
+# Open http://127.0.0.1:8765 in browser, first visit redirects to /setup to create admin
+```
+
+Support single run (PayPal billing agreement / GoPay / QRIS / promo long links) + concurrent mode (frontend configured with phone pool + concurrency N), public network access via nginx reverse proxy see [`webui/README.md`](webui/README.md).
+
+### Installation
+
+```bash
+git clone https://github.com/DanOps-1/Gpt-Agreement-Payment
+cd Gpt-Agreement-Payment
+pip install requests curl_cffi playwright camoufox browserforge mitmproxy pybase64
+playwright install firefox
+camoufox fetch
+```
+
+hCaptcha solver ML dependencies (torch / transformers / opencv) are recommended to be installed separately in a venv, approximately 4 GB:
+
+```bash
+python -m venv ~/.venvs/ctfml
+~/.venvs/ctfml/bin/pip install torch transformers opencv-python pillow numpy
+```
+
+# Complete dependency list and system packages, see [`docs/installation.md`](docs/installation.md).
+
+### Configuration
+
+Copy the template and fill in values:
+
+```bash
+cp CTF-pay/config.paypal.example.json     CTF-pay/config.paypal.json
+cp CTF-reg/config.paypal-proxy.example.json   CTF-reg/config.paypal-proxy.json
+```
+
+For field meanings and schema, see [`docs/configuration.md`](docs/configuration.md). The Docker deployment entrypoint will automatically bootstrap these two config files on first startup. After editing on the host, run `docker compose restart webui` to take effect.
+
+### Running
+
+> Docker users only need to use webui to run. The CLI commands below are for users running natively locally; to run the same commands in Docker, first `docker compose exec webui bash` to enter the container.
+
+```bash
+# 1) Single complete workflow (PayPal billing agreement)
+xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal
+
+# 2) Plus protocol authorization + promo long link (PayPal guest checkout)
+xvfb-run -a python scripts/no_card_paypal_plus.py \
+    --config CTF-pay/config.paypal.json --paypal-node-rpa \
+    --phone <your_phone> --otp-timeout 240
+
+# 3) N worker concurrency (same phone is fine, OTP phase auto-queues via advisory lock)
+# Recommended to start via webui: select concurrency mode, frontend configures phone pool + concurrency N
+
+# 4) Continuous account pool maintenance
+xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal --daemon
+```
+
+# Four Operating Modes (Single / Batch / Self-Dealer / Daemon) + Concurrency Mode Differences and Parameters
+
+See [`docs/operating-modes.md`](docs/operating-modes.md).
+
+---
+
+## Documentation
+
+| Documentation | Content |
+|---|---|
+| [`docs/installation.md`](docs/installation.md) | System dependencies, Python packages, ML venv, gost relay, first PayPal login |
+| [`docs/configuration.md`](docs/configuration.md) | All JSON fields, environment variables, CF API token application |
+| [`docs/architecture.md`](docs/architecture.md) | Subsystems, file organization, protocol chain details |
+| [`docs/operating-modes.md`](docs/operating-modes.md) | Single / Batch / Self-Dealer / Daemon / Concurrency detailed parameters |
+| [`docs/hcaptcha-solver.md`](docs/hcaptcha-solver.md) | Three-layer decision-making, 12 question types, standalone invocation, extending new question types |
+| [`docs/daemon-mode.md`](docs/daemon-mode.md) | 12-path self-healing loop trigger conditions and state machine |
+| [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md) | Complete anti-fraud empirical data and corrected models |
+| [`docs/debugging.md`](docs/debugging.md) | Common exceptions, artifact paths, troubleshooting commands |
+
+---
+
+## Known Limitations
+
+- **PayPal billing agreement only available in EU**. Stripe account restrictions; can only place orders as EU identities like IE.
+- **PayPal guest checkout path subject to multiple risk controls**. `INSTRUMENT_SHARING_LIMIT_EXCEEDED` / `CC_LINKED_TO_FULL_ACCOUNT` / `CREATE_CARD_ACCOUNT_CANDIDATE_VALIDATION_ERROR` / DataDome captcha etc. will all trigger; the script has early exit + automatic retry branches for each known error.
+- **Batch registration next-day survival rate ~2%**. This is caused by batch correlation effects in ChatGPT's anti-fraud mechanism, not the tool itself. See [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md).
+- **Free account path currently not working**. OpenAI changed the free account secondary login flow; redirect to `/add-phone` cannot be bypassed without a real phone number; ChatGPT-Web client's access_token calling Codex API has audience mismatch.
+- **Stripe runtime fingerprint drifts**. `runtime.version` / `js_checksum` / `rv_timestamp` need realignment approximately every few weeks.
+- **hCaptcha question type coverage incomplete**. Current 12 common types; when uncovered, VLM directly outputs coordinates as fallback, success rate not guaranteed.
+- **Concurrency shares single exit IP**. Webshare pool currently can only provide a single IP; N workers traverse the same IP; recommended concurrency ≤ 3 to avoid PayPal/DataDome risk control joint punishment. Multi-IP pool support on roadmap.
+- **Code style somewhat rough**. `_monolith.py` arranged sequentially by protocol stage, comments mix Chinese and English, not suitable as a Python engineering example.
+
+---
+
+## Contribution
+
+Most valuable contributions ranked by impact:
+
+1. New hCaptcha question type solvers
+2. Protocol adaptation when Stripe / PayPal / OpenAI introduces breaking changes
+3. New failure mode daemon self-healing branches observed in practice (with logs)
+4. Anti-fraud empirical data supplements (desensitization format per existing examples)
+5. Multi-IP pool / proxy rotation implementation to free concurrency from single IP limitation
+6. Documentation improvement / translation
+
+> ⚠️ **Maintainers cannot manually reproduce PRs**. When submitting PRs, please follow the [PR template](.github/PULL_REQUEST_TEMPLATE.md) providing **detailed description + running evidence** (requirements vary by change type: solver question types need round JSON, protocol adaptation needs packet capture comparison, daemon self-healing needs trigger logs and recovery logs). PRs lacking evidence will be closed without explanation.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for complete workflow, code style, and desensitization checklist for research contributions.
+See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for community guidelines.
+Do not open issues for security problems; see [`SECURITY.md`](SECURITY.md).
+
+---
+
+## Acknowledgments
+
+Key dependencies in the tool chain:
+
+- [Camoufox](https://github.com/daijro/camoufox) — antidetect Firefox build, foundation of the entire browser automation layer
+- [mitmproxy](https://mitmproxy.org/) — protocol packet capture
+- [Playwright](https://playwright.dev/) — browser automation
+- [curl_cffi](https://github.com/lexiforest/curl_cffi) — TLS fingerprint simulation
+- [OpenAI CLIP](https://github.com/openai/CLIP) — visual backbone for heuristic solver
+- [gost](https://github.com/go-gost/gost) — SOCKS5 relay
+
+### Code Contributors
+
+Thanks to the following friends for code contributions (by PR time):
+
+- [@Lium-7768](https://github.com/Lium-7768) — [#12](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/12) Align GoPay step visibility to hide 06 and 13
+- [@DragonBaiMo](https://github.com/DragonBaiMo) — [#15](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/15) Algorithmicized persona generator + email name co-sourcing
+- [@laochendeai](https://github.com/laochendeai) — [#21](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/21) detect blocking challenge pages
+
+## Community
+
+| Channel | Purpose |
+|---|---|
+| [**LINUX DO**](https://linux.do/) | Main technical discussions, protocol research feedback, long-term records |
+| QQ Group **`1028722105`** | Real-time Chinese community exchange |
+| GitHub Issues | Bug reports and PRs (main entry point) |
+
+Special thanks to the LINUX DO community — the earliest feedback sources, testers, and protocol change reporters all come from here.
+
+---
+
+## Sponsorship
+
+If this project has been helpful to you, you're welcome to buy the author a coffee ☕
+
+<p align="center">
+  <img src="goodgood.jpg" width="280" alt="Sponsorship QR code">
+</p>
+
+### Donation Thanks
+
+Thanks to the following friends for their support (no particular order):
+
+| Sponsor | Amount |
+|---|---|
+| Galaxy-n | ¥101 |
+| 两岁 | ¥100 |
+| 朴朴配送员 | ¥66 |
+| Ka | ¥28.88 |
+| 追Mou | ¥20 |
+| 原昊 | ¥20 |
+| A. | ¥10 |
+| acedia | ¥9.1 |
+| 至上松一 | ¥6.66 |
+| 书忆江南 | ¥5 |
+| 辛昊 | ¥5 |
+| bensema | ¥0.66 |
+| Earth NPC | ¥0.01 |
+| 小水獭 | ¥0.01 |
+| 钟 | ¥0.01 |
+
+The gesture matters more than the amount; every bit of support is motivation to continue maintaining the project 🙏
+
+---
+
+## Star History
+
+<a href="https://star-history.com/#DanOps-1/Gpt-Agreement-Payment&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=DanOps-1/Gpt-Agreement-Payment&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=DanOps-1/Gpt-Agreement-Payment&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=DanOps-1/Gpt-Agreement-Payment&type=Date" />
+  </picture>
+</a>
+
+---
+
+## Disclaimer
+
+> [!IMPORTANT]
+> **Using this project constitutes your acceptance of having fully read, completely understood, and explicitly agreed to all terms in [`NOTICE`](NOTICE).** If you cannot accept — do not use this project, delete all copies.
+
+License is [MIT](LICENSE), but the License itself is not the complete disclaimer. Full disclaimer terms are in [`NOTICE`](NOTICE); below is the key summary:
+
+**This project is provided "AS IS" without warranties of any kind.** Including but not limited to merchantability, fitness for a particular purpose, non-infringement, safety, stability, and continued compatibility with third-party services. You assume all risks of using this project.
+
+**Use only within authorized scope.** Permitted: systems you own, legal CTF, authorized bug bounty projects on in-scope assets, security research. **Prohibited**: fraud, payment evasion, bulk account creation for resale, violating third-party ToS, unauthorized targets.
+
+**You bear all legal responsibility.** Including but not limited to account suspension, payment loss, criminal liability, civil damages, administrative penalties, third-party claims, reputation loss, business loss. Applicable laws may include US CFAA, EU GDPR, UK CMA, China Criminal Law Articles 285/286/287, etc. See section 4 of [`NOTICE`](NOTICE).
+
+**Maintainers have no obligation to reply to issues, review PRs, fix bugs, maintain availability, or adapt to protocol changes.** Reserved the right to archive, delete, rename, or stop maintaining this project at any time without prior notice.
+
+Uncertain whether your use is legal — **do not run**. Ask a lawyer first, or talk to the target platform's security team.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **简体中文** | [English](README.en.md)
+
 <p align="center">
   <img src="docs/images/logo-light.png#gh-light-mode-only" width="120" alt="Gpt-Agreement-Payment logo">
   <img src="docs/images/logo-dark.png#gh-dark-mode-only"   width="120" alt="Gpt-Agreement-Payment logo">
@@ -5,289 +7,315 @@
 
 # Gpt-Agreement-Payment
 
-End-to-end replay tool for ChatGPT Plus / Team subscription agreements: reverse-engineered from packet capture the entire chain `Stripe Checkout → PayPal / GoPay / QRIS → ChatGPT manual-approval → Codex OAuth + PKCE` and implemented as a runnable client. Includes a from-scratch hCaptcha visual solver, PayPal fraud detection early-exit branch, and a set of empirical anti-fraud mechanism data collected from real execution.
+ChatGPT Plus / Team 订阅协议的端到端重放工具：从抓包逆出 `Stripe Checkout → PayPal / GoPay / QRIS → ChatGPT manual-approval → Codex OAuth + PKCE` 整条链路，并实现成可运行客户端。附带从零实现的 hCaptcha 视觉求解器、PayPal 风控早退分支、和一组真实运行采集的反欺诈机制实证数据。
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
 [![CI](https://img.shields.io/github/actions/workflow/status/DanOps-1/Gpt-Agreement-Payment/ci.yml?label=CI)](https://github.com/DanOps-1/Gpt-Agreement-Payment/actions)
-[![Use](https://img.shields.io/badge/use-CTF%20%2F%20bug%20bounty-red)](#legal-boundary)
+[![Use](https://img.shields.io/badge/use-CTF%20%2F%20bug%20bounty-red)](#法律边界)
 
 ---
 
-## Public Benefit API Relay Station
+## 公益 API 中转站
 
-| Logo | Name | Description | Website |
+| Logo | 名称 | 介绍 | 官网 |
 | --- | --- | --- | --- |
-| <a href="https://api.lukyface.com/" target="_blank"><img src="docs/images/sponsors/lukyface.png" alt="lukyface API" width="140" /></a> | lukyface API (Author-run · Public Benefit Station) | Unified AI model aggregation / distribution gateway (based on new-api), OpenAI / Claude / Gemini protocol interconversion, self-use surplus sharing. **Pure public benefit, non-profit**.<br><br>**Open only to [LINUX DO](https://linux.do/) users** · **Payment in LDC (Linux Do in-site currency) only** · Public benefit station exchange group: **`1107410931`** | [https://api.lukyface.com/](https://api.lukyface.com/) |
+| <a href="https://api.lukyface.com/" target="_blank"><img src="docs/images/sponsors/lukyface.png" alt="lukyface API" width="140" /></a> | lukyface API（作者自营 · 公益站） | 统一的 AI 模型聚合 / 分发网关（基于 new-api），OpenAI / Claude / Gemini 三协议互转，自用余量分享。**纯公益、非盈利**。<br><br>**仅对 [LINUX DO](https://linux.do/) 用户开放** · **只接受 LDC（Linux Do 站内货币）支付** · 公益站交流群：**`1107410931`** | [https://api.lukyface.com/](https://api.lukyface.com/) |
 
 ---
 
 > [!CAUTION]
-> **Using this project constitutes acceptance of all terms in [`NOTICE`](NOTICE).** The project is provided AS IS, with no warranties, and the maintainers assume no responsibility. Authorized use only on systems you own / legitimate CTF / authorized bug bounty in-scope assets / security research. **Strictly prohibited** for fraud, payment evasion, bulk account creation for resale, violation of third-party ToS, unauthorized targets. All legal responsibility rests with the user. If you do not accept these terms, **do not use**.
+> **使用本项目即视为同意 [`NOTICE`](NOTICE) 的全部条款。** 项目按 AS IS 提供、无任何担保、维护者不负任何责任。仅限你拥有的系统 / 合法 CTF / 授权 bug bounty 项目 in-scope 资产 / 安全研究。**严禁**用于欺诈、规避支付、批量造号转售、违反第三方 ToS、未授权目标。一切法律责任由使用者自负。不接受条款就**不要使用**。
 
 ---
 
-## What This Is
+## 这是什么
 
-Supports four subscription activation paths:
+支持四条订阅开通路径：
 
-| Path | Entry Point | Use Case |
+| 路径 | 入口 | 用途 |
 |---|---|---|
-| **Team / Plus (PayPal billing agreement)** | `pipeline.py --paypal` | Stripe Checkout → PayPal billing agreement → ChatGPT manual approval |
-| **Plus (promo long link + PayPal agreement auth)** | `scripts/no_card_paypal_plus.py` | OpenAI official promo campaign long link + PayPal guest checkout completing billing agreement protocol |
-| **Plus / Team (GoPay Indonesia)** | `pipeline.py --gopay` | Midtrans linking + GoPay wallet binding, IDR region exclusive |
-| **Plus / Team (QRIS scan)** | `pipeline.py --qris` | Midtrans QRIS, remote preview + reference polling settlement |
+| **Team / Plus（PayPal billing agreement）** | `pipeline.py --paypal` | Stripe Checkout → PayPal billing agreement → ChatGPT manual approval |
+| **Plus（promo 长链接 + PayPal 协议授权）** | `scripts/no_card_paypal_plus.py` | OpenAI 官方 promo campaign 长链接 + PayPal guest checkout 走完 billing agreement 协议 |
+| **Plus / Team（GoPay 印尼）** | `pipeline.py --gopay` | Midtrans linking + GoPay 钱包绑定，IDR 区域专用 |
+| **Plus / Team（QRIS 扫码）** | `pipeline.py --qris` | Midtrans QRIS，远端预览 + reference 轮询结算 |
 
-Given a clean proxy + payment credential, run the command to completion and get the OAuth `refresh_token`.
+给一个干净代理 + 一个支付凭证，命令跑完拿到 OAuth `refresh_token`。
 
-Four points worth examining:
+四个值得看的点：
 
-- **N-worker concurrency + phone-lock OTP critical section mutual exclusion** (`webui/backend/parallel_runner.py`). Same phone across multiple workers serializes OTP phase using advisory lock, pre/post-OTP fully parallelized; DB atomic claim + placeholder INSERT prevents multiple workers contending for same promo_link / same inventory email. Frontend configures phone pool (M rows) + concurrency N (can exceed M), worker maps to phone pool via `i % M` round-robin.
-- **hCaptcha visual solver** (`CTF-pay/hcaptcha_auto_solver.py`, ~4000 lines, independently usable). VLM primary path + CLIP/OpenCV heuristic fallback + Playwright human action synthesis, covers 12 known hCaptcha question types.
-- **Anti-fraud mechanism empirical data**. IP string-level exact fingerprinting, batch correlation delayed banning, probe layer vs ban layer separation. Measured sample of ~2% 24-hour survival rate across 45 accounts, including corrected models. See [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md).
-- **Twelve-path self-healing daemon loops** (`pipeline.py::daemon()`). Webshare API auto IP rotation (webshare jitter fallback to `/tmp/gost_last.json` cache), CF DNS quota cleanup, tmpfs orphan recovery, gost relay watchdog, DataDome slider auto-drag. Design goal is unattended operation for weeks.
+- **N-worker 并发 + phone-lock OTP 临界区互斥**（`webui/backend/parallel_runner.py`）。同 phone 多 worker 用 advisory lock 串行 OTP 阶段，pre/post-OTP 全并行；DB atomic claim + 占位 INSERT 防多 worker 抢同 promo_link / 同 inventory 邮箱。前端配 phone 池（M 行） + 并发数 N（可大于 M），worker 按 `i % M` 轮询映射到 phone 池。
+- **hCaptcha 视觉求解器**（`CTF-pay/hcaptcha_auto_solver.py`，约 4000 行，独立可用）。VLM 主路径 + CLIP/OpenCV 启发式回退 + Playwright 人类动作合成，覆盖 12 种已知 hCaptcha 题型。
+- **反欺诈机制实证数据**。IP 字符串级精确指纹、批次关联延迟封禁、probe 层 vs ban 层分离。45 个号 24 小时存活率约 2% 的实测样本，含修正模型。详见 [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md)。
+- **十二路自愈环 daemon**（`pipeline.py::daemon()`）。Webshare API 自动换 IP（webshare 抖时回退到 `/tmp/gost_last.json` cache）、CF DNS 配额清理、tmpfs 孤儿回收、gost 中继看门狗、DataDome 滑块自动拖拽。设计目标是无人值守跑数周。
 
 ---
 
-## Architecture```mermaid
+## 架构
+
+```mermaid
 flowchart LR
     A[pipeline.py / webui] --> B[CTF-reg/<br/>browser_register.py<br/>Camoufox + Turnstile]
-    B --> C[CTF-pay/card.py<br/>Stripe Checkout replay]
-    C --> D{Payment path}
+    B --> C[CTF-pay/card.py<br/>Stripe Checkout 重放]
+    C --> D{支付路径}
     D -->|paypal| E1[Camoufox / Node RPA<br/>PayPal billing agreement]
     D -->|gopay| E2[Midtrans linking<br/>+ WhatsApp OTP]
-    D -->|qris| E3[QRIS QR<br/>+ remote preview]
+    D -->|qris| E3[QRIS QR<br/>+ 远端预览]
     E1 --> F[Stripe poll<br/>state=succeeded]
     E2 --> F
     E3 --> F
-    F --> G[Camoufox second login<br/>Codex OAuth + PKCE]
+    F --> G[Camoufox 二次登录<br/>Codex OAuth + PKCE]
     G --> H[refresh_token<br/>output/webui.db &#40;SQLite&#41;]
-```For detailed subsystem decomposition, file organization, and protocol chain details, see [`docs/architecture.md`](docs/architecture.md).
+```
+
+详细子系统拆解、文件分工、协议链路细节看 [`docs/architecture.md`](docs/architecture.md)。
 
 ---
 
-## Current Status and Entry Barriers
+## 现状与门槛
 
-To be frank, this is not an out-of-the-box tool. Running through the entire pipeline requires at least:
+实事求是讲，这不是个开箱即用的工具。要把整条链路跑通，至少需要：
 
-- A real, login-capable PayPal account (or go through PayPal guest checkout authorization flow)
-- A proxy with exit in EU / US / ID (region locked based on selected payment path)
-- A Cloudflare zone (optional, for enabling catch-all subdomain email registration; also supports Outlook code pool)
-- A Linux machine capable of running Camoufox + Playwright (approximately 5 GB disk + 2 GB memory)
-- (Required for PayPal guest checkout) An SMS code gateway API key for PayPal signup
-- (Required for GoPay) A WhatsApp online number + WhatsApp code verification service
-- (Optional) An OpenAI-compatible VLM API key for hCaptcha solving; residential / pseudo-residential exits typically don't trigger hCaptcha, and CLIP degradation is available without VLM
-- (Optional) A captcha solving platform API key compatible with createTask/getTaskResult protocol as a fallback for browser passive captcha
+- 一个真实可登录的 PayPal 账号（也可走 PayPal guest checkout 协议授权流程）
+- 一个出口在 EU / US / ID 的代理（按选择的支付路径锁地区）
+- 一个 Cloudflare zone（可选，用于开 catch-all 子域注册邮箱；也支持 Outlook 接码池）
+- 一台能跑 Camoufox + Playwright 的 Linux（约 5 GB 磁盘 + 2 GB 内存）
+- （PayPal guest checkout 必需）一个 SMS 接码网关 API key，PayPal signup 用
+- （GoPay 必需）一个 WhatsApp 在线号 + WhatsApp 接码服务
+- （可选）一个 OpenAI 兼容的 VLM API key，hCaptcha 求解用；家宽 / 伪家宽出口通常不会触发 hCaptcha，无 VLM 时也会降级到 CLIP
+- （可选）一个兼容 createTask/getTaskResult 协议的打码平台 API key，作为浏览器 passive captcha 的兜底
 
-Full end-to-end setup typically takes 1–3 hours for initial configuration tuning. Once daemon mode runs stably, a single pipeline takes ~5 minutes; concurrent mode with 2 workers on the same phone generates 2 accounts in ~3 minutes.
+第一次完整跑通通常要花 1–3 小时调通配置。daemon 模式跑稳后，单次 pipeline 约 5 分钟；并发模式同 phone 跑 2 worker 约 3 分钟拿 2 个号。
 
-Code is research-oriented, organized by protocol stage, and doesn't prioritize maximum readability.
+代码偏研究性质，按协议阶段顺排，不追求可读性最大化。
 
 ---
 
-## Getting Started
+## 上手
 
-### Beginner Path: WebUI Configuration Wizard (Recommended)
+### 新手路径：webui 配置向导（推荐）
 
-Compress 1–3 hours of manual configuration into ~15 minutes. 14-step wizard + real-time preflight self-checks + built-in runtime controller (SSE log stream + concurrency panel) generate `CTF-pay/config.auto.json` + `CTF-reg/config.paypal-proxy.json` configurations.
+把 1–3 小时的手动调配压到 ~15 分钟。14 步 wizard + 实时 preflight 自检 + 内置运行控制器（SSE 日志流 + 并发面板），生成 `CTF-pay/config.auto.json` + `CTF-reg/config.paypal-proxy.json` 两份配置。
 
-![WebUI screenshot](docs/images/webui.png)
+![webui 截图](docs/images/webui.png)
 
-#### Docker Deployment (Fastest Path, One-Click Start)
+#### Docker 部署（最快路径，一键起）
 
-The repo comes with `Dockerfile` (multi-stage build: Node frontend + Ubuntu 24.04 runtime) + `docker-compose.yml`, packing all system dependencies / Playwright Chromium+Firefox / Camoufox / gost SOCKS5 relay / Node QuickJS (for OpenAI Sentinel) into the image. The git working tree on the host serves as the single source of truth, bind-mounted into the container; restart with `docker compose restart` for instant effect after modifying Python code, no rebuild needed.```bash
+仓库自带 `Dockerfile`（多阶段 build：node 前端 + ubuntu 24.04 runtime）+ `docker-compose.yml`，把所有系统依赖 / Playwright Chromium+Firefox / Camoufox / gost SOCKS5 中继 / Node QuickJS（OpenAI Sentinel 用）全打进镜像。host 上的 git working tree 作为单一真实源，整仓 bind mount 进容器，改完 Python 代码 `docker compose restart` 即时生效，不用重 build。
+
+```bash
 git clone https://github.com/DanOps-1/Gpt-Agreement-Payment
 cd Gpt-Agreement-Payment
 docker compose up -d --build
-# Default listening on 127.0.0.1:8765 (host port), open http://127.0.0.1:8765/ in browser
-# First visit redirects to /setup to create admin
-```# Common Maintenance Commands:```bash
-# Real-time logs
+# 默认监听 127.0.0.1:8765（host 端口），浏览器开 http://127.0.0.1:8765/
+# 首次访问跳 /setup 创建管理员
+```
+
+常用维护命令：
+
+```bash
+# 实时日志
 docker compose logs -f webui
 
-# Debug inside container (pip list / run tests / inspect SQLite)
+# 进容器调试（pip list / 跑测试 / inspect SQLite）
 docker compose exec webui bash
 
-# Reload uvicorn after Python code changes (bind mount already syncs source code, just restart process)
+# 改完 Python 代码后让 uvicorn 重载（bind mount 已 sync 源码，只需重启进程）
 docker compose restart webui
 
-# Rebuild dist in container after frontend code changes
+# 改完前端代码后在容器内 rebuild dist
 docker compose exec webui sh -c "cd /app/webui/frontend && npm run build"
 
-# Completely stop + clean containers
+# 完全停 + 清容器
 docker compose down
 
-# Image upgrade (pull new base / upgrade Python packages)
+# 镜像升级 (拉新 base / 升 Python 包)
 docker compose build --no-cache && docker compose up -d
-```# Data Persistence
+```
 
-The `output/` directory is a host directory bind mount containing `webui.db` (SQLite) + run results / logs visible and backupable to the host. `webui/frontend/dist` and `node_modules` use anonymous volumes, which are overridden by the baked image version (not overridden by an empty host directory).
+数据落盘：`output/` 是 host 目录 bind mount，里面 `webui.db`（SQLite）+ 运行结果 / 日志 host 可见可备份。`webui/frontend/dist` 和 `node_modules` 走 anonymous volume，被镜像 baked 版本覆盖（不被 host 空目录覆盖）。
 
-## Public Access (nginx Reverse Proxy + HTTPS)
+公网访问（nginx 反代 + HTTPS）见 [`webui/README.md`](webui/README.md)。默认 `docker-compose.yml` 把端口绑 `127.0.0.1:8765`；要直接 `0.0.0.0` 暴露请改 `ports` 段（不建议，没认证层在前面）。
 
-See [`webui/README.md`](webui/README.md). By default, `docker-compose.yml` binds the port to `127.0.0.1:8765`; to expose directly to `0.0.0.0`, modify the `ports` section (not recommended without an authentication layer in front).
+#### 手装（不用 Docker）
 
-#### Manual Installation (without Docker)```bash
-# 1. Backend dependencies
+```bash
+# 1. 后端依赖
 pip install -r webui/requirements.txt
 
-# 2. Frontend build (one-time)
+# 2. 前端构建（一次性）
 cd webui/frontend && pnpm i && pnpm build && cd ../..
 
-# 3. Start
+# 3. 启动
 python -m webui.server
-# Open http://127.0.0.1:8765 in browser, first visit redirects to /setup to create admin
-```Support single run (PayPal billing agreement / GoPay / QRIS / promo long links) + concurrent mode (frontend configured with phone pool + concurrency N), public network access via nginx reverse proxy see [`webui/README.md`](webui/README.md).
+# 浏览器打开 http://127.0.0.1:8765 ，首次访问跳 /setup 建管理员
+```
 
-### Installation```bash
+支持单 run（PayPal billing agreement / GoPay / QRIS / promo 长链接）+ 并发模式（前端配 phone 池 + 并发数 N），公网访问通过 nginx 反代见 [`webui/README.md`](webui/README.md)。
+
+### 装
+
+```bash
 git clone https://github.com/DanOps-1/Gpt-Agreement-Payment
 cd Gpt-Agreement-Payment
 pip install requests curl_cffi playwright camoufox browserforge mitmproxy pybase64
 playwright install firefox
 camoufox fetch
-```hCaptcha solver ML dependencies (torch / transformers / opencv) are recommended to be installed separately in a venv, approximately 4 GB:```bash
+```
+
+hCaptcha 求解器的 ML 依赖（torch / transformers / opencv）建议单独装到 venv，约 4 GB：
+
+```bash
 python -m venv ~/.venvs/ctfml
 ~/.venvs/ctfml/bin/pip install torch transformers opencv-python pillow numpy
-```# Complete dependency list and system packages, see [`docs/installation.md`](docs/installation.md).
+```
 
-### Configuration
+完整依赖清单和系统包看 [`docs/installation.md`](docs/installation.md)。
 
-Copy the template and fill in values:```bash
+### 配
+
+复制模板，填值：
+
+```bash
 cp CTF-pay/config.paypal.example.json     CTF-pay/config.paypal.json
 cp CTF-reg/config.paypal-proxy.example.json   CTF-reg/config.paypal-proxy.json
-```For field meanings and schema, see [`docs/configuration.md`](docs/configuration.md). The Docker deployment entrypoint will automatically bootstrap these two config files on first startup. After editing on the host, run `docker compose restart webui` to take effect.
+```
 
-### Running
+字段含义和 schema 看 [`docs/configuration.md`](docs/configuration.md)。Docker 部署的 entrypoint 第一次启动时会自动 bootstrap 这两份 config，host 编辑后 `docker compose restart webui` 生效。
 
-> Docker users only need to use webui to run. The CLI commands below are for users running natively locally; to run the same commands in Docker, first `docker compose exec webui bash` to enter the container.```bash
-# 1) Single complete workflow (PayPal billing agreement)
+### 跑
+
+> Docker 用户用 webui 跑就够了。下面的 CLI 命令是给本地原生跑的用户；Docker 里要跑同样命令先 `docker compose exec webui bash` 进容器。
+
+```bash
+# 1) 单次完整流程 (PayPal billing agreement)
 xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal
 
-# 2) Plus protocol authorization + promo long link (PayPal guest checkout)
+# 2) Plus 协议授权 + promo 长链接 (走 PayPal guest checkout)
 xvfb-run -a python scripts/no_card_paypal_plus.py \
     --config CTF-pay/config.paypal.json --paypal-node-rpa \
-    --phone <your_phone> --otp-timeout 240
+    --phone <你的号> --otp-timeout 240
 
-# 3) N worker concurrency (same phone is fine, OTP phase auto-queues via advisory lock)
-# Recommended to start via webui: select concurrency mode, frontend configures phone pool + concurrency N
+# 3) N worker 并发 (同 phone 也行, OTP 阶段会 advisory lock 自动排队)
+# 推荐用 webui 启动: 选并发模式, 前端配 phone 池 + concurrency N
 
-# 4) Continuous account pool maintenance
+# 4) 持续维护补号池
 xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal --daemon
-```# Four Operating Modes (Single / Batch / Self-Dealer / Daemon) + Concurrency Mode Differences and Parameters
+```
 
-See [`docs/operating-modes.md`](docs/operating-modes.md).
+四种运行模式（单次 / 批量 / self-dealer / daemon）+ 并发模式的差异和参数看 [`docs/operating-modes.md`](docs/operating-modes.md)。
 
 ---
 
-## Documentation
+## 文档
 
-| Documentation | Content |
+| 文档 | 内容 |
 |---|---|
-| [`docs/installation.md`](docs/installation.md) | System dependencies, Python packages, ML venv, gost relay, first PayPal login |
-| [`docs/configuration.md`](docs/configuration.md) | All JSON fields, environment variables, CF API token application |
-| [`docs/architecture.md`](docs/architecture.md) | Subsystems, file organization, protocol chain details |
-| [`docs/operating-modes.md`](docs/operating-modes.md) | Single / Batch / Self-Dealer / Daemon / Concurrency detailed parameters |
-| [`docs/hcaptcha-solver.md`](docs/hcaptcha-solver.md) | Three-layer decision-making, 12 question types, standalone invocation, extending new question types |
-| [`docs/daemon-mode.md`](docs/daemon-mode.md) | 12-path self-healing loop trigger conditions and state machine |
-| [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md) | Complete anti-fraud empirical data and corrected models |
-| [`docs/debugging.md`](docs/debugging.md) | Common exceptions, artifact paths, troubleshooting commands |
+| [`docs/installation.md`](docs/installation.md) | 系统依赖、Python 包、ML venv、gost 中继、第一次登 PayPal |
+| [`docs/configuration.md`](docs/configuration.md) | 所有 JSON 字段、环境变量、CF API token 申请 |
+| [`docs/architecture.md`](docs/architecture.md) | 子系统、文件组织、协议链路细节 |
+| [`docs/operating-modes.md`](docs/operating-modes.md) | 单次 / 批量 / self-dealer / daemon / 并发 详细参数 |
+| [`docs/hcaptcha-solver.md`](docs/hcaptcha-solver.md) | 三层决策、12 题型、独立调用、扩展新题型 |
+| [`docs/daemon-mode.md`](docs/daemon-mode.md) | 12 路自愈环触发条件与状态机 |
+| [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md) | 反欺诈实证完整数据与修正模型 |
+| [`docs/debugging.md`](docs/debugging.md) | 常见异常、产物路径、排错命令 |
 
 ---
 
-## Known Limitations
+## 已知限制
 
-- **PayPal billing agreement only available in EU**. Stripe account restrictions; can only place orders as EU identities like IE.
-- **PayPal guest checkout path subject to multiple risk controls**. `INSTRUMENT_SHARING_LIMIT_EXCEEDED` / `CC_LINKED_TO_FULL_ACCOUNT` / `CREATE_CARD_ACCOUNT_CANDIDATE_VALIDATION_ERROR` / DataDome captcha etc. will all trigger; the script has early exit + automatic retry branches for each known error.
-- **Batch registration next-day survival rate ~2%**. This is caused by batch correlation effects in ChatGPT's anti-fraud mechanism, not the tool itself. See [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md).
-- **Free account path currently not working**. OpenAI changed the free account secondary login flow; redirect to `/add-phone` cannot be bypassed without a real phone number; ChatGPT-Web client's access_token calling Codex API has audience mismatch.
-- **Stripe runtime fingerprint drifts**. `runtime.version` / `js_checksum` / `rv_timestamp` need realignment approximately every few weeks.
-- **hCaptcha question type coverage incomplete**. Current 12 common types; when uncovered, VLM directly outputs coordinates as fallback, success rate not guaranteed.
-- **Concurrency shares single exit IP**. Webshare pool currently can only provide a single IP; N workers traverse the same IP; recommended concurrency ≤ 3 to avoid PayPal/DataDome risk control joint punishment. Multi-IP pool support on roadmap.
-- **Code style somewhat rough**. `_monolith.py` arranged sequentially by protocol stage, comments mix Chinese and English, not suitable as a Python engineering example.
-
----
-
-## Contribution
-
-Most valuable contributions ranked by impact:
-
-1. New hCaptcha question type solvers
-2. Protocol adaptation when Stripe / PayPal / OpenAI introduces breaking changes
-3. New failure mode daemon self-healing branches observed in practice (with logs)
-4. Anti-fraud empirical data supplements (desensitization format per existing examples)
-5. Multi-IP pool / proxy rotation implementation to free concurrency from single IP limitation
-6. Documentation improvement / translation
-
-> ⚠️ **Maintainers cannot manually reproduce PRs**. When submitting PRs, please follow the [PR template](.github/PULL_REQUEST_TEMPLATE.md) providing **detailed description + running evidence** (requirements vary by change type: solver question types need round JSON, protocol adaptation needs packet capture comparison, daemon self-healing needs trigger logs and recovery logs). PRs lacking evidence will be closed without explanation.
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for complete workflow, code style, and desensitization checklist for research contributions.
-See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for community guidelines.
-Do not open issues for security problems; see [`SECURITY.md`](SECURITY.md).
+- **PayPal billing agreement 仅 EU 开通**。Stripe 账号限制，只能以 IE 等欧盟身份下单。
+- **PayPal guest checkout 路径受多重风控**。`INSTRUMENT_SHARING_LIMIT_EXCEEDED` / `CC_LINKED_TO_FULL_ACCOUNT` / `CREATE_CARD_ACCOUNT_CANDIDATE_VALIDATION_ERROR` / DataDome captcha 等都会触发；脚本对每种已知错误都有早退 + 自动重试分支。
+- **批量注册次日存活率约 2%**。这是 ChatGPT 反欺诈机制的批次关联效应导致的，不是工具本身的问题。详见 [`docs/anti-fraud-research.md`](docs/anti-fraud-research.md)。
+- **免费账号路径目前不通**。OpenAI 改了 free 账号二次登录流程，重定向到 `/add-phone` 没真实手机号绕不过；ChatGPT-Web client 的 access_token 调 Codex API audience 不匹配。
+- **Stripe runtime 指纹会漂**。`runtime.version` / `js_checksum` / `rv_timestamp` 大约几周一次需要重新对齐。
+- **hCaptcha 题型覆盖不全**。当前 12 种常见题，未覆盖时由 VLM 直出坐标兜底，不保证成功率。
+- **并发共享单出口 IP**。webshare 池现状只能给单一 IP，N worker 走同一 IP；建议并发 ≤ 3 以免被 PayPal/DataDome 风控连坐。多 IP 池支持在 roadmap。
+- **代码风格偏粗放**。`_monolith.py` 按协议阶段顺排，注释混中英文，不适合作为 Python 工程范例。
 
 ---
 
-## Acknowledgments
+## 贡献
 
-Key dependencies in the tool chain:
+最有价值的贡献按影响力排序：
 
-- [Camoufox](https://github.com/daijro/camoufox) — antidetect Firefox build, foundation of the entire browser automation layer
-- [mitmproxy](https://mitmproxy.org/) — protocol packet capture
-- [Playwright](https://playwright.dev/) — browser automation
-- [curl_cffi](https://github.com/lexiforest/curl_cffi) — TLS fingerprint simulation
-- [OpenAI CLIP](https://github.com/openai/CLIP) — visual backbone for heuristic solver
-- [gost](https://github.com/go-gost/gost) — SOCKS5 relay
+1. 新的 hCaptcha 题型 solver
+2. Stripe / PayPal / OpenAI 出 breaking change 时的协议适配
+3. 实战中观察到的新失败模式的 daemon 自愈分支（带日志）
+4. 反欺诈实证数据补充（脱敏方式参考现有写法）
+5. 多 IP 池 / proxy 轮换实现，让并发摆脱单 IP 限制
+6. 文档完善 / 翻译
 
-### Code Contributors
+> ⚠️ **维护者无法手动复现 PR**。所以提 PR 时请按 [PR 模板](.github/PULL_REQUEST_TEMPLATE.md) 提供**详细说明 + 跑通证据**（按改动类型不同要求不同：solver 题型要 round JSON、协议适配要抓包对比、daemon 自愈要触发日志和恢复日志）。证据缺了 PR 直接关，不解释。
 
-Thanks to the following friends for code contributions (by PR time):
+完整工作流、代码风格、研究内容贡献的脱敏清单看 [`CONTRIBUTING.md`](CONTRIBUTING.md)。
+社区准则看 [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)。
+安全问题别公开提 issue，看 [`SECURITY.md`](SECURITY.md)。
+
+---
+
+## 致谢
+
+工具链上的几个核心依赖：
+
+- [Camoufox](https://github.com/daijro/camoufox) — antidetect Firefox build，整个浏览器自动化层的基础
+- [mitmproxy](https://mitmproxy.org/) — 协议抓包
+- [Playwright](https://playwright.dev/) — 浏览器自动化
+- [curl_cffi](https://github.com/lexiforest/curl_cffi) — TLS 指纹模拟
+- [OpenAI CLIP](https://github.com/openai/CLIP) — 启发式 solver 的视觉骨架
+- [gost](https://github.com/go-gost/gost) — SOCKS5 中继
+
+### 代码贡献者
+
+感谢以下朋友贡献代码（按 PR 时间）：
 
 - [@Lium-7768](https://github.com/Lium-7768) — [#12](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/12) Align GoPay step visibility to hide 06 and 13
-- [@DragonBaiMo](https://github.com/DragonBaiMo) — [#15](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/15) Algorithmicized persona generator + email name co-sourcing
+- [@DragonBaiMo](https://github.com/DragonBaiMo) — [#15](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/15) 算法化 persona 生成器 + 邮箱姓名同源
 - [@laochendeai](https://github.com/laochendeai) — [#21](https://github.com/DanOps-1/Gpt-Agreement-Payment/pull/21) detect blocking challenge pages
 
-## Community
+## 社区
 
-| Channel | Purpose |
+| 渠道 | 用途 |
 |---|---|
-| [**LINUX DO**](https://linux.do/) | Main technical discussions, protocol research feedback, long-term records |
-| QQ Group **`1028722105`** | Real-time Chinese community exchange |
-| GitHub Issues | Bug reports and PRs (main entry point) |
+| [**LINUX DO**](https://linux.do/) | 主要技术讨论、协议研究反馈、长期记录 |
+| QQ 群 **`1028722105`** | 中文圈实时交流 |
+| GitHub Issues | bug 报告与 PR（主入口） |
 
-Special thanks to the LINUX DO community — the earliest feedback sources, testers, and protocol change reporters all come from here.
+特别感谢 LINUX DO 社区 —— 本项目最早的反馈来源、实测者、协议变化通报者都来自这里。
 
 ---
 
-## Sponsorship
+## 赞赏
 
-If this project has been helpful to you, you're welcome to buy the author a coffee ☕
+如果这个项目对你有帮助，欢迎请作者喝杯咖啡 ☕
 
 <p align="center">
-  <img src="goodgood.jpg" width="280" alt="Sponsorship QR code">
+  <img src="goodgood.jpg" width="280" alt="赞赏码">
 </p>
 
-### Donation Thanks
+### 打赏致谢
 
-Thanks to the following friends for their support (no particular order):
+感谢以下朋友的支持（排名不分先后）：
 
-| Sponsor | Amount |
+| 打赏者 | 金额 |
 |---|---|
-| Galaxy-n | ¥101 |
-| 两岁 | ¥100 |
-| 朴朴配送员 | ¥66 |
-| Ka | ¥28.88 |
-| 追Mou | ¥20 |
-| 原昊 | ¥20 |
-| A. | ¥10 |
-| acedia | ¥9.1 |
-| 至上松一 | ¥6.66 |
-| 书忆江南 | ¥5 |
-| 辛昊 | ¥5 |
-| bensema | ¥0.66 |
-| Earth NPC | ¥0.01 |
-| 小水獭 | ¥0.01 |
-| 钟 | ¥0.01 |
+| Galaxy-n | 101 元 |
+| 两岁 | 100 元 |
+| 朴朴配送员 | 66 元 |
+| Ka | 28.88 元 |
+| 追Mou | 20 元 |
+| 原昊 | 20 元 |
+| A. | 10 元 |
+| acedia | 9.1 元 |
+| 至上松一 | 6.66 元 |
+| 书忆江南 | 5 元 |
+| 辛昊 | 5 元 |
+| bensema | 0.66 元 |
+| Earth NPC | 0.01 元 |
+| 小水獭 | 0.01 元 |
+| 钟 | 0.01 元 |
 
-The gesture matters more than the amount; every bit of support is motivation to continue maintaining the project 🙏
+心意比金额更珍贵，每一份支持都是项目继续维护的动力 🙏
 
 ---
 
@@ -303,19 +331,21 @@ The gesture matters more than the amount; every bit of support is motivation to 
 
 ---
 
-## Disclaimer
+## 免责声明
 
 > [!IMPORTANT]
-> **Using this project constitutes your acceptance of having fully read, completely understood, and explicitly agreed to all terms in [`NOTICE`](NOTICE).** If you cannot accept — do not use this project, delete all copies.
+> **使用本项目即视为你已完整阅读、完全理解、并明确接受 [`NOTICE`](NOTICE) 的全部条款。** 不能接受 —— 不要使用本项目，删除所有副本。
 
-License is [MIT](LICENSE), but the License itself is not the complete disclaimer. Full disclaimer terms are in [`NOTICE`](NOTICE); below is the key summary:
+License 是 [MIT](LICENSE)，但 License 本身不是免责的全部。完整免责条款在 [`NOTICE`](NOTICE)，下面是关键摘要：
 
-**This project is provided "AS IS" without warranties of any kind.** Including but not limited to merchantability, fitness for a particular purpose, non-infringement, safety, stability, and continued compatibility with third-party services. You assume all risks of using this project.
+**本项目按"现状（AS IS）"提供，不附任何形式的担保。** 包括但不限于适销性、适用于特定用途、不侵权、安全性、稳定性、与第三方服务的持续兼容性。你独自承担使用本项目的一切风险。
 
-**Use only within authorized scope.** Permitted: systems you own, legal CTF, authorized bug bounty projects on in-scope assets, security research. **Prohibited**: fraud, payment evasion, bulk account creation for resale, violating third-party ToS, unauthorized targets.
+**仅限授权范围内使用。** 允许：你拥有的系统、合法 CTF、授权 bug bounty 项目内 in-scope 资产、安全研究。**禁止**：欺诈、规避支付、批量造号转售、违反第三方平台 ToS、未授权目标。
 
-**You bear all legal responsibility.** Including but not limited to account suspension, payment loss, criminal liability, civil damages, administrative penalties, third-party claims, reputation loss, business loss. Applicable laws may include US CFAA, EU GDPR, UK CMA, China Criminal Law Articles 285/286/287, etc. See section 4 of [`NOTICE`](NOTICE).
+**法律责任完全由使用者承担。** 包括但不限于账号封禁、付款损失、刑事责任、民事赔偿、行政处罚、第三方索赔、声誉损失、商业损失。可能适用的法律包括美国 CFAA、欧盟 GDPR、英国 CMA、中国《刑法》第 285/286/287 条等。具体看 [`NOTICE`](NOTICE) 第 4 节。
 
-**Maintainers have no obligation to reply to issues, review PRs, fix bugs, maintain availability, or adapt to protocol changes.** Reserved the right to archive, delete, rename, or stop maintaining this project at any time without prior notice.
+**维护者无义务回复 issue、审查 PR、修复 bug、维护可用性、做协议适配。** 保留任何时候归档、删除、改名、停止维护本项目的权利，不需要事先通知。
 
-Uncertain whether your use is legal — **do not run**. Ask a lawyer first, or talk to the target platform's security team.
+**本项目不属于、不附属于、不被授权于、不被赞助于** OpenAI、Stripe、PayPal、Cloudflare、hCaptcha 或任何提及的第三方服务。所有商标归各自所有者。
+
+不确定使用是否合法 —— **不要运行**。先问律师，或者先跟目标平台的安全团队聊。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,57 +1,57 @@
-# Security Policy
+# 安全策略
 
-## Reporting Vulnerabilities in This Project
+## 报告本项目的漏洞
 
-If you discover a security issue in **`Gpt-Agreement-Payment` itself** — credential leaks, configuration loader injection, unsafe deserialization, SSRF in helper scripts, etc. — please report it privately and do not open a public issue.
+如果你在 **`Gpt-Agreement-Payment` 自己**身上发现了安全问题 —— 凭证泄露、配置加载器的注入、不安全的反序列化、辅助脚本的 SSRF 之类 —— 请私下报，别公开提 issue。
 
-**Channels** (by priority):
+**通道**（按优先级）：
 
-1. GitHub private vulnerability report: **Security → Report a vulnerability** in the repository
-2. Find the maintainer's email through the repository owner's GitHub profile
+1. GitHub 私密漏洞报告：仓库的 **Security → Report a vulnerability**
+2. 通过仓库 owner 的 GitHub profile 找到维护者邮箱
 
-Please provide:
+请提供：
 
-- Affected files and line numbers
-- Minimal reproduction steps
-- Your estimated impact (auth bypass? RCE? credential exposure?)
-- Whether you should be credited in the fix
+- 受影响的文件和行号
+- 最小复现步骤
+- 你估计的影响（auth bypass？RCE？凭证暴露？）
+- 修复时是否要署名
 
-**Response timeline**: We aim to reply within 7 days and fix or mitigate within 30 days. Community-maintained, so please understand if it's slower.
-
----
-
-## Out of Scope
-
-This project is a protocol research tool. Findings about *target services* (Stripe, PayPal, ChatGPT, hCaptcha, Cloudflare, Webshare, etc.) should be reported directly to **the respective vendors** through their bug bounty programs:
-
-- **OpenAI** — https://openai.com/security/disclosure/
-- **Stripe** — https://stripe.com/.well-known/security.txt
-- **PayPal** — via HackerOne: https://hackerone.com/paypal
-- **Cloudflare** — https://hackerone.com/cloudflare
-- **hCaptcha (Intuition Machines)** — https://www.hcaptcha.com/security
-
-We do **not** report or triage findings to target services on your behalf, and cannot provide vendors with authenticated reproduction environments. That's a conversation between you and the vendor.
+**响应时效**：尽量 7 天内首回复，30 天内修或缓解。志愿者维护，慢一点请理解。
 
 ---
 
-## Authorized Use Only
+## 不在受理范围
 
-By using this software, you confirm that:
+本项目是协议研究工具。关于*目标服务*（Stripe、PayPal、ChatGPT、hCaptcha、Cloudflare、Webshare 等）的发现请直接报给**对应厂商**，走它们各自的 bug bounty：
 
-- You are testing **your own** systems, or you have **explicit written authorization** to test the systems in question (e.g., assets explicitly in-scope in a bug bounty program)
-- You will not use this toolkit for fraud, payment evasion, bulk account creation, or violation of any third-party platform's ToS
-- You understand that running this against unauthorized targets may be illegal, including but not limited to the US **CFAA**, UK **Computer Misuse Act**, **GDPR / CCPA** privacy laws, and fraud statutes in various jurisdictions
+- **OpenAI** —— https://openai.com/security/disclosure/
+- **Stripe** —— https://stripe.com/.well-known/security.txt
+- **PayPal** —— 通过 HackerOne：https://hackerone.com/paypal
+- **Cloudflare** —— https://hackerone.com/cloudflare
+- **hCaptcha (Intuition Machines)** —— https://www.hcaptcha.com/security
 
-Maintainers will not assist, recommend, or accept contributions intended for unauthorized use. Such Issues / PRs are closed without response. Serious cases (publicly bragging about ToS violations, asking for help defrauding a specific company, etc.) result in bans.
+我们**不**代你向目标服务报告或 triage，也没法给厂商提供已认证的复现环境。这些是你跟厂商直接谈的事。
 
 ---
 
-## Responsible Disclosure for Fraud Research
+## 仅限授权使用
 
-The anti-fraud empirical section in [`README.md`](README.md#-anti-fraud-empirical) describes **defense mechanisms observed in production**, at the same level of abstraction as CAPTCHA-breaking papers and fingerprinting attack papers in academic literature. Specifically:
+用本软件即表示你确认：
 
-- All numerical IPs are RFC 5737 placeholder ranges (`203.0.113.0/24`, `198.51.100.0/24`, `192.0.2.0/24`)
-- All domains written are `*.example` placeholders
-- Account counts, timelines, and reasoning are authentic — that's the research's actual value
+- 你测的是**你自己的**系统，或者你有**明确书面授权**测的系统（比如某个 bug bounty 项目里相关资产明确在 scope 内）
+- 你不会拿这套工具搞欺诈、规避支付、批量造号、违反任何第三方平台的 ToS
+- 你知道针对未授权目标跑这套工具可能违法，包括但不限于美国 **CFAA**、英国 **Computer Misuse Act**、**GDPR / CCPA** 隐私法规以及各国诈骗罪
 
-If OpenAI / Cloudflare or similar defense operators believe any material crosses into operational details that should be redacted, please submit a private vulnerability report (see above) to discuss. We have no interest in publishing content that meaningfully undermines defense posture; but we **do** care about making the *abstract structure* of these defense mechanisms public so future system designs can account for them.
+维护者不协助、不建议、不接受任何意图未授权使用的贡献。这类 Issue / PR 直接关，不回复。情节严重的（公开炫耀违反 ToS、求帮忙诈骗某具体公司之类）封禁。
+
+---
+
+## 反欺诈研究的负责任披露
+
+[`README.md` 反欺诈实证段](README.md#-反欺诈实证) 描述的是**生产环境观察到的防御机制**，抽象层级跟 CAPTCHA-breaking 论文、指纹关联攻击论文这类学术文献是一个量级的。具体说：
+
+- 所有数字 IP 都是 RFC 5737 文档段占位符（`203.0.113.0/24`、`198.51.100.0/24`、`192.0.2.0/24`）
+- 所有写到的域名都是 `*.example` 占位符
+- 账号数、时间、推理是真的 —— 那才是研究本身的价值
+
+如果 OpenAI / Cloudflare 之类公司的防守方觉得里面有什么材料越界到该删的运营细节，请提交私密漏洞报告（看上面）一起讨论。我们没兴趣发那些会有意义削弱防御态势的内容；但**有**兴趣让这些防御机制的*抽象结构*公开，让以后的系统设计能纳入考量。

--- a/docs/anti-fraud-research.md
+++ b/docs/anti-fraud-research.md
@@ -1,47 +1,47 @@
-# Anti-Fraud Empirical Research
+# 反欺诈实证研究
 
-[← Back to README](../README.md)
+[← 回到 README](../README.md)
 
-> All data in this document comes from actual production runs. **IPs are masked using RFC 5737 documentation ranges (`203.0.113.0/24`, `198.51.100.0/24`, `192.0.2.0/24`), domains are masked with `*.example`**, account counts and timestamps are unchanged — that is the core of the research itself.
-
----
-
-## Abstract
-
-ChatGPT Team's anti-fraud mechanism operates on two independent layers with very different behavioral characteristics:
-
-1. **Probe layer** (real-time): Account-level / domain-level signals, evaluated in real-time at request time, labeled by **exact IP string** and **domain string**
-2. **Ban layer** (delayed batch): Batch association signals, executed by backend cron jobs (typical windows `00:00 UTC` and `12:00 UTC`), reviewed by packaging `(time_window, payment_account, exit_ip, fingerprint)` tuples
-
-**Single PayPal + single IP + dense registration has ~2% survival rate over 24 hours.** This is not a technical issue, but a hard limit of batch association itself. To significantly improve survival rate, you must reduce batch association: multiple PayPals, multiple ISP/city IPs, time distribution, and fingerprint diversity.
+> 本文所有数据均来自真实生产运行。**IP 用 RFC 5737 文档段（`203.0.113.0/24`、`198.51.100.0/24`、`192.0.2.0/24`）占位，域名用 `*.example` 占位**，账号数和时间未做修改 —— 那是研究本身的核心。
 
 ---
 
-## Experiment 1: 45-Account Batch, 24-Hour Survival Rate
+## 摘要
 
-### Experiment Setup
+ChatGPT Team 的反欺诈机制有两个独立的层面，行为差异很大：
 
-- Single day window (~14 hour span)
-- **Single PayPal account** (PayPal-A)
-- **Single exit IP** (`203.0.113.10`, labeled IP-A)
-- **Seven adjacent subdomains** (5 `*.zone-a.example` + `zone-b.example` + `zone-c.example`)
-- Total creation: **45 accounts**
+1. **Probe 层**（即时）：账号级 / 域级信号，请求时即时评估，按**精确 IP 字符串**和**域字符串**打标
+2. **Ban 层**（延迟批次）：批次关联信号，由后端定时任务跑（典型时间窗 `00:00 UTC` 和 `12:00 UTC`），按 `(时间窗口, 支付账号, 出口 IP, 指纹)` 元组打包审查
 
-### Statistics at Probe Time
+**单 PayPal + 单 IP + 密集注册 24 小时存活率约 2%。** 这不是技术问题，是批次关联本身的 hard limit。要把存活率显著拉起来，必须降低批次关联：多 PayPal、多 ISP/城市 IP、时间散开、指纹多样化。
 
-| Result | Count |
+---
+
+## 实验 1：45 账号批次，24 小时存活率
+
+### 实验设置
+
+- 单日窗口（约 14 小时跨度）
+- **同一个 PayPal 账号**（PayPal-A）
+- **同一个出口 IP**（`203.0.113.10`，记为 IP-A）
+- **七个相邻子域**（5 个 `*.zone-a.example` + `zone-b.example` + `zone-c.example`）
+- 创建总数 **45 个**
+
+### Probe 时统计
+
+| 结果 | 次数 |
 |---|---|
 | `probe=ok` | 32 |
-| `probe=no_permission` | 1 (domain `zone-c.example`, known persistent label) |
-| Other errors | 12 |
+| `probe=no_permission` | 1（`zone-c.example`，已知持久打标的域） |
+| 其他错误 | 12 |
 
-From the probe perspective, it appeared "32 accounts active, 1 domain has issues."
+按 probe 时的视角看，似乎"32 个号生效，1 个域有问题"。
 
-### 24-Hour Survival Rate
+### 24 小时存活率
 
-Direct query on `gpt_accounts` table:
+直接查 `gpt_accounts` 表：
 
-| Domain | Created | Banned | Survived | Avg `user_count` |
+| 域 | 创建数 | BAN | 存活 | 平均 `user_count` |
 |---|---:|---:|---:|---:|
 | `subA1.zone-a.example` | 15 | 15 | 0 | 2.3 |
 | `subA2.zone-a.example` | 8 | 8 | 0 | 4.0 |
@@ -50,192 +50,197 @@ Direct query on `gpt_accounts` table:
 | `subA5.zone-a.example` | 5 | 5 | 0 | 3.6 |
 | `zone-b.example` | 5 | 5 | 0 | 3.6 |
 | `zone-c.example` | 1 | 1 | 0 | 1.0 |
-| **Total** | **45** | **44** | **1** | — |
+| **合计** | **45** | **44** | **1** | — |
 
-**24-hour survival: 1/45 ≈ 2.2%.**
+**24 小时后存活 1/45 ≈ 2.2%。**
 
-### Seat Occupancy Distribution (Banned Accounts)
+### 座位填充率分布（被封号的）
 
-Downstream users filling seats also got banned:
+下游真有用户填进去的号也照样被封：
 
-| user_count | Banned accounts |
+| user_count | 被封号数 |
 |---|---:|
 | 5 / 5 | 17 |
 | 4 / 5 | 13 |
 | 3 / 5 | 4 |
 | 2 / 5 | 1 |
 | 1 / 5 | 8 |
-| Full + 1 invite pending | 1 |
+| 满座 + 1 邀请中 | 1 |
 
-**Seat occupancy is irrelevant to survival.** Bans don't check downstream usage; they check creation-time association.
+**座位填充率跟存活无关。** 封禁不看下游用没用，看的是创建时刻的关联性。
 
-### Bulk BAN Timestamps
+### 批量 BAN 时间戳
 
-Aggregation of `updated_at` field (by ban status change time):
+`updated_at` 字段聚合（按 banned 状态变化时间）：
 
-| Time Window | Concentrated Bans |
+| 时间窗口 | 集中封禁数 |
 |---|---:|
-| 2026-04-19 12:xx UTC | 29 accounts |
-| 2026-04-19 07:xx UTC | 4 accounts |
-| Other scattered | 11 accounts |
+| 2026-04-19 12:xx UTC | 29 个 |
+| 2026-04-19 07:xx UTC | 4 个 |
+| 其他零散 | 11 个 |
 
-**Review runs on fixed cron** (presumed `00:00 UTC` and `12:00 UTC` vicinity). The `07:xx` wave may be another batch review window.
+**审查跑在固定 cron 上**（推测 `00:00 UTC` 和 `12:00 UTC` 附近）。`07:xx` 那波可能是另一个分批审查窗口。
 
-### Survivor Analysis
+### 幸存对照
 
-Only one account survived (`subA3.zone-a.example`, created 4/18 19:03, 5 seats full). **This is very likely review evasion, not genuinely stable.** One account created 5 days earlier (`subA4.zone-a.example`, created 4/14 23:19, 5+1 seats) remains active, suggesting early batches become stable after passing a certain observation period.
+只有一个号活了下来（`subA3.zone-a.example` 4/18 19:03 创建，5 座满）。**这极可能是审查漏网，不是真的稳。** 一个早 5 天创建的号（`subA4.zone-a.example` 4/14 23:19，5+1 座位）至今仍活，说明早批次过了某个观察期反而稳定。
 
 ---
 
-## Experiment 2: IP Dimension Control (Dual Proxy)
+## 实验 2：IP 维度对照（双代理）
 
-### Setup
+### 设置
 
-- Same batch of `*.zone-a.example` subdomain candidates (10 total)
-- Two proxy exit controls:
-  - Proxy X: `203.0.113.10` (NY, ISP-A, AS-XX) — **same IP-A as Experiment 1**
-  - Proxy Y: `203.0.113.20` (VA, ISP-B, AS-YY) — clean IP
-- Same PayPal-A, same Camoufox fingerprint
+- 同一批 `*.zone-a.example` 子域候选（10 个）
+- 两个代理出口对照：
+  - 代理 X：`203.0.113.10`（NY，ISP-A，AS-XX）—— **同实验 1 的 IP-A**
+  - 代理 Y：`203.0.113.20`（VA，ISP-B，AS-YY）—— 干净 IP
+- 同一个 PayPal-A，同一个 Camoufox 指纹
 
-### Results
+### 结果
 
-| Proxy | Exit IP | Probe `ok` Count | Completed | `ok` Rate |
+| 代理 | 出口 IP | Probe `ok` 次数 | 完成数 | `ok` 率 |
 |---|---|---:|---:|---:|
-| X (NY) | `203.0.113.10` | 1 | 7 | **14%** |
-| Y (VA) | `203.0.113.20` | 3 | 3 | **100%** |
+| X（NY） | `203.0.113.10` | 1 | 7 | **14%** |
+| Y（VA） | `203.0.113.20` | 3 | 3 | **100%** |
 
-**Same subdomain `subA3.zone-a.example`: returns `no_perm` from X, returns `ok` from Y.**
+**同一个子域 `subA3.zone-a.example`：从 X 出去 `no_perm`，从 Y 出去 `ok`。**
 
-### Conclusion
+### 结论
 
-**Domain is not the primary factor; IP is.** The probe layer labels by IP.
+**域不是主因，IP 是主因。** Probe 层的打标针对 IP。
 
 ---
 
-## Experiment 3: Same ASN, Different IP
+## 实验 3：同 ASN 不同 IP
 
-### Setup
+### 设置
 
-Switch to proxy Z: `203.0.113.30`, **same ISP (ISP-A), same city (NY), same ASN (AS-XX) as IP-A, but different IP string**.
+切换到代理 Z：`203.0.113.30`，**和 IP-A 同 ISP（ISP-A）、同城市（NY）、同 ASN（AS-XX）**，但 IP 字符串不同。
 
-Re-test the same batch of subdomains immediately.
+立即复测同一批子域。
 
-### Results
+### 结果
 
-| Proxy | Exit IP | Probe `ok` | Completed | `ok` Rate | When `no_perm` Triggered |
+| 代理 | 出口 IP | Probe `ok` | 完成数 | `ok` 率 | 触发 `no_perm` 时机 |
 |---|---|---:|---:|---:|---|
-| X (old NY, labeled) | `203.0.113.10` | 1 | 7 | 14% | Refused on 2nd attempt |
-| **Z (new NY, clean)** | `203.0.113.30` | **4** | **5** | **80%** | **Refused only on 5th attempt** |
+| X（旧 NY，已打标） | `203.0.113.10` | 1 | 7 | 14% | 第 2 次就拒 |
+| **Z（新 NY，干净）** | `203.0.113.30` | **4** | **5** | **80%** | **第 5 次才拒** |
 
-### Conclusion
+### 结论
 
-**Switching to a different IP within the same ISP/city/ASN immediately restores "clean state."**
+**换同 ISP / 同城市 / 同 ASN 内的另一个 IP，立刻恢复"干净状态"。**
 
-→ ChatGPT's labeling granularity is **exact IP string**, not ASN / city / ISP.
+→ ChatGPT 打标粒度是**精确 IP 字符串**，不是 ASN / 城市 / ISP。
 
-### IP Lifespan
+### IP 寿命
 
-Each IP can run approximately **4–5 registrations** before flipping to `no_perm` state (probe starts rejecting on 5th attempt). Recovery methods:
+每个 IP 大约能跑 **4–5 次**注册就会翻到 `no_perm` 状态（第 5 次 probe 开始拒）。恢复办法：
 
-- **Change IP**: Immediate recovery (same ASN is fine, as long as IP string differs)
-- **Wait a few hours**: Natural recovery (reference observation of `subA1.zone-a.example` temporary 2h recovery)
+- **换 IP**：立即恢复（同 ASN 也行，只要 IP 字符串不同）
+- **等几小时**：自然恢复（参考 `subA1.zone-a.example` 短暂 2h 恢复的观察）
 
 ---
 
-## Debunked Early Assumptions
+## 推翻的早期假设
 
-| Early Assumption | Data | Debunked |
+| 早期假设 | 数据 | 推翻 |
 |---|---|---|
-| Anti-fraud granularity is "registration email domain" | Five clean subdomains cleared on same day | ❌ It's batch association, not by-domain |
-| `*.zone-a.example` five subdomains all stable | All five subdomain batches cleared same day | ❌ These five domains' accounts cleared together, all looked "ok" before banning |
-| Same IP + same PayPal + concentrated registration won't trigger anti-fraud (12 consecutive ok) | 24h survival ≈ 2% | ❌ probe=ok is just real-time state |
-| Single day 30+ won't trigger new burn | 45 accounts concentrated ban | ❌ Yes it does, just delayed 12 hours |
-| `probe=no_perm` is domain-level labeling | Same domain returns opposite results under different IPs | ❌ The dominant signal is IP |
+| 反欺诈粒度是"注册邮箱域" | 五个干净子域同日被清 | ❌ 是批次关联，不按域 |
+| `*.zone-a.example` 五个子域全稳 | 五个批次同日被清 | ❌ 这五个域的号同批被清，没被封之前看着都"ok" |
+| 同 IP + 同 PayPal + 集中注册不会触发反欺诈（连续 12 次 ok） | 24h 存活 ≈ 2% | ❌ probe=ok 只是即时态 |
+| 单日 30+ 不会触发新 burn | 45 个号集中被封 | ❌ 会，只是延迟 12 小时 |
+| `probe=no_perm` 是域级打标 | 同域在不同 IP 下结果相反 | ❌ 主导信号是 IP |
 
 ---
 
-## Revised Anti-Fraud Model
+## 修正后的反欺诈模型
 
-### Two Independent Mechanisms```
+### 两层独立机制
+
+```
 ┌─────────────────────────────────────────────────────┐
-│                Probe Layer (Immediate)              │
+│                Probe 层（即时）                     │
 │                                                     │
 │  signal = (egress_ip_string, email_domain_string?)  │
 │  evaluation = at request time                       │
-│  IP lifetime = ~4-5 registrations                   │
-│  domain-level tagging = few domains permanently     │
-│                        unavailable                  │
+│  IP 寿命 = ~4-5 次注册                              │
+│  域级打标 = 少数域永久不可用                        │
 └─────────────────────────────────────────────────────┘
                        ↓
-                registration may succeed
+                  注册可能 ok
                        ↓
 ┌─────────────────────────────────────────────────────┐
-│                Ban Layer (Delayed Batch)            │
+│                Ban 层（延迟批次）                   │
 │                                                     │
 │  signal = (time_window, payment_account,            │
 │            egress_ip, fingerprint, ...)             │
 │  evaluation = scheduled cron @ ~00:00 / 12:00 UTC  │
-│  entire batch correlation → entire batch banned     │
+│  整批关联 → 整批被封                                │
 └─────────────────────────────────────────────────────┘
                        ↓
-                95% death rate next day at dawn
-```# Key Insights
+                次日凌晨 95% 死亡
+```
 
-1. **Probe=ok does not mean stability.** It only means the cohort hasn't been reviewed yet
-2. **Domain-level tagging is rare** (e.g., `zone-c.example`), with narrower applicability than expected
-3. **IP string is the dominant signal at the probe layer**
-4. **Batch association is the dominant signal at the ban layer**, which requires reducing dimension sharing within cohorts to improve
+### 关键认知
 
----
-
-## Engineering Impact
-
-### What existing tools can manage
-
-- ✅ DomainPool + permanent_burned handle probe-layer "persistent-tagged domains"
-- ✅ Webshare API + gost relay handle IP lifespan issues
-- ✅ Multi-zone domain pool handle CF quota + zone-level risk
-
-### What existing tools cannot manage
-
-- ❌ **Next-day mass extinction caused by batch association**: daemon mode with target=20 inventory may drop to 0–1 after a single batch BAN, essentially restarting each night
-- ❌ Domain rotation / on-demand subdomain provisioning are ineffective against "next-day mass extinction"
-
-### Methods to improve 24-hour survival rate
-
-To significantly reduce batch association (ordered by effectiveness):
-
-1. **Multiple PayPal account pool**: 1–3 orders per account, then rotate and stagger timing. This is the strongest signal
-2. **Multiple proxy exit IPs across ISPs / cities**: Different ISPs' actual slots, not just multiple slots from the same proxy vendor
-3. **Time dispersion**: 2–3 per day, spread hours apart, not 30+ in one hour
-4. **Camoufox fingerprint diversification**: `humanize` + different OS/screen profiles
-5. **Lower single PayPal reuse rate**: Reusing the same PayPal for multiple Team subscriptions in short timeframes is itself a strong fraud signal
-
-The current pipeline only does "60–180s jitter staggering" and "multi-domain rotation", **all other dimensions use identical parameters**. This is the root cause of the 2% survival rate.
+1. **Probe=ok 不代表稳定。** 只代表 cohort 还没被审到
+2. **域级打标是少数情况**（如 `zone-c.example`），适用范围比想象中小
+3. **IP 字符串是 probe 层的主导信号**
+4. **批次关联是 ban 层的主导信号**，需要降低 cohort 内的维度共享才能改善
 
 ---
 
-## Directions to be verified
+## 工程层面的影响
 
-The following have insufficient experimental data; left for future researchers:
+### 现有工具能管的
 
-1. **Real ROI of Camoufox fingerprint diversification**: Do different OS/screen profiles truly increase cohort distance?
-2. **PayPal trust decay curve**: Survival rate trajectory after a PayPal runs N orders
-3. **Optimal time dispersion interval**: How much interval between different cohorts is sufficient to be "independent"
-4. **Fingerprint reuse vs IP reuse weight**: Hold other dimensions constant, contrastive testing
-5. **Existence of a "warm-up" path**: Does performing some "normal user" behavior before banning occur reduce closure probability
+- ✅ DomainPool + permanent_burned 处理 probe 层的"持久打标域"
+- ✅ Webshare API + gost 中继处理 IP 寿命问题
+- ✅ 多 zone 域池处理 CF 配额 + zone 级风险
+
+### 现有工具管不了的
+
+- ❌ **批次关联导致的次日大灭绝**：daemon 模式 target=20 的库存在一次批量 BAN 后可能只剩 0–1 个，相当于每晚重新起步
+- ❌ 域轮换 / 按需开通子域对"次日大灭绝"无效
+
+### 提高 24 小时存活率的方法
+
+要显著降低批次关联（按效果排序）：
+
+1. **多 PayPal 账号池**：每个账号 1–3 单后轮换，拉开时间。这是最强信号
+2. **多代理出口 IP，跨 ISP / 跨城市**：不是同一代理商的多个 slot，而是真的不同 ISP
+3. **时间分散**：单日 2–3 个，错开几小时，而不是一小时密集 30+
+4. **Camoufox 指纹多样化**：`humanize` + 不同 OS/屏幕 profile
+5. **降低单 PayPal 复用率**：同一 PayPal 短时间内多次 Team 订阅本身就是强欺诈信号
+
+目前 pipeline 只做到"错开 60–180s 抖动"和"多域轮换"，**其他维度全是同参数**。这是 2% 存活率的根因。
 
 ---
 
-## Reproduction Guide
+## 待验证的方向
 
-To reproduce these experiments:
+下面这几条没有充分实验数据，留给后来人做：
 
-1. Prepare at least 2 proxy exits with different ASNs
-2. Configure daemon mode to run for a week or longer
-3. Query daily the `is_banned` status changes in the `gpt_accounts` table via sqlite3
-4. Key query:```sql
--- Batch characteristics of accounts banned within 24 hours
+1. **Camoufox 指纹多样化的真实 ROI**：不同 OS/屏幕 profile 是否真能拉开 cohort 距离？
+2. **PayPal 信任度衰减**：一个 PayPal 跑过 N 单后存活率变化曲线
+3. **时间分散的最佳间隔**：不同 cohort 之间间隔多久才足够"独立"
+4. **指纹复用 vs IP 复用 哪个权重更高**：固定其他维度，对照测试
+5. **是否存在 "warm-up" 路径**：一个号在 ban 之前先做一些"正常用户"的行为是否能降低被封概率
+
+---
+
+## 复现指引
+
+要复现这些实验：
+
+1. 准备至少 2 个不同 ASN 的代理出口
+2. 配 daemon 模式跑一周以上
+3. 每天用 sqlite3 直查 `gpt_accounts` 表的 `is_banned` 状态变化
+4. 关键查询：
+
+```sql
+-- 24h 内被封号的批次特征
 SELECT
     DATE(created_at) AS create_day,
     HOUR(updated_at) AS ban_hour,
@@ -247,19 +252,27 @@ WHERE is_banned = 1
   AND updated_at > created_at + INTERVAL '12 hours'
 GROUP BY 1, 2, 3, 4
 ORDER BY 1 DESC, 2 DESC;
-```5. Control groups are organized by dimensional differences (same PayPal vs different PayPal, same IP vs different IP, etc.)
-6. Data anonymization methods refer to this article (RFC 5737 IP, `*.example` domain names)
+```
 
-If you generate new data, feel free to submit a PR to add it to this article following [`CONTRIBUTING.md`](../CONTRIBUTING.md#data-anonymization-checklist-for-research-contributions).
+5. 对照组按维度差异分组（同 PayPal vs 不同 PayPal、同 IP vs 不同 IP 等等）
+6. 数据脱敏方式参考本文（RFC 5737 IP、`*.example` 域名）
+
+如果你跑出来新数据，欢迎按 [`CONTRIBUTING.md`](../CONTRIBUTING.md#研究内容贡献的脱敏清单) 提 PR 加到本文。
 
 ---
 
-## Citing this article
+## 引用本文
 
-If your research / paper / blog cites data from this article, please cite:```
-Gpt-Agreement-Payment — Anti-Fraud Empirical Research. (2026).
+如果你的研究 / 论文 / 博客引用本文中的数据，请引用：
+
+```
+Gpt-Agreement-Payment — 反欺诈实证研究. (2026).
 https://github.com/DanOps-1/Gpt-Agreement-Payment/blob/main/docs/anti-fraud-research.md
-```Or BibTeX:```bibtex
+```
+
+或者 BibTeX：
+
+```bibtex
 @misc{Gpt-Agreement-Payment-antifraud,
   title  = {Empirical Anti-Fraud Research on ChatGPT Team Subscription},
   author = {Gpt-Agreement-Payment contributors},

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,179 +1,207 @@
-# Architecture Explained
+# 架构详解
 
-[← Back to README](../README.md)
+[← 回到 README](../README.md)
 
-## Top-Level Process```mermaid
+## 顶层流程
+
+```mermaid
 flowchart LR
     A[pipeline.py] --> B[CTF-reg/<br/>browser_register.py<br/>Camoufox + Turnstile]
-    B --> C[CTF-pay/card.py<br/>Stripe Checkout Replay]
+    B --> C[CTF-pay/card.py<br/>Stripe Checkout 重放]
     C --> D[Stripe confirm<br/>+ ChatGPT /approve]
-    D --> E[Camoufox PayPal<br/>Protocol Authorization]
+    D --> E[Camoufox PayPal<br/>协议授权]
     E --> F[Stripe poll<br/>state=succeeded]
-    F --> G[Camoufox Second Login<br/>Codex OAuth + PKCE]
+    F --> G[Camoufox 二次登录<br/>Codex OAuth + PKCE]
     G --> H[refresh_token<br/>output/webui.db &#40;SQLite&#41;]
-    H --> I[Optional: Push to gpt-team /<br/>CPA / Other Downstream]
-```## File Organization```
-Gpt-Agreement-Payment/
-├── pipeline.py                     # Orchestrator: single/batch/daemon/self-dealer
-├── CTF-pay/                        # Stripe + PayPal protocol replay
-│   ├── card.py                     # Main program, ~8000 lines
-│   ├── hcaptcha_auto_solver.py     # Vision solving (VLM + CLIP + Playwright)
-│   ├── hcaptcha_bridge_helper.py   # Interactive debug tool
-│   ├── local_mock_gateway.py       # Stripe state machine local mock
-│   ├── retry_house_decline.py      # Card decline terminal state retry wrapper
-│   └── config.*.json               # Template in repo, runtime config gitignored
-├── CTF-reg/                        # ChatGPT registration subsystem
-│   ├── browser_register.py         # Camoufox real browser registration
-│   ├── auth_flow.py                # Pure HTTP registration (fallback)
-│   ├── sentinel.py                 # OpenAI Sentinel PoW token
-│   ├── mail_provider.py            # Generate catch-all mailbox + delegate cf_kv_otp_provider for OTP
-│   ├── cf_kv_otp_provider.py       # Read OTP from Cloudflare KV (worker writes)
-│   ├── http_client.py              # curl_cffi/requests factory
-│   └── config.py                   # dataclass config definition
-├── docs/                           # Detailed documentation
-└── output/                         # Runtime artifacts (gitignored)
-    ├── webui.db                    # SQLite runtime store
-    ├── SQLite runtime_meta[daemon_state]
-    └── logs/
-```---
-
-## Subsystems
-
-### `CTF-pay/` —— Payment Protocol Replay Main Program
-
-#### `card.py` (approximately 8000 lines single file)
-
-Intentionally implemented as a single large program, organized by functional sections rather than split into modules. Reasons:
-
-- The protocol pipeline is a single linear flow; splitting modules would increase cross-file navigation overhead
-- Large amounts of local state are passed between stages; splitting would result in unwieldy parameter lists
-- Single file enables easier holistic reading and quick location of code
-
-Main sections:
-
-| Section | Approximate Lines | Content |
-|---|---|---|
-| Config loading | 200–600 | `load_config()`, JSON validation, CLI parsing |
-| HTTP client | 600–1100 | curl_cffi wrapper, TLS fingerprinting, proxy |
-| Stripe protocol | 1100–3000 | init / lookup / confirm / 3DS / poll |
-| ChatGPT auth | 3000–4500 | session management, access_token refresh |
-| Camoufox | 4500–6000 | PayPal browser flow, secondary login OAuth |
-| Exceptions + main entry | 6000–8000 | exception classification, daemon hooks, command entry |
-
-#### `hcaptcha_auto_solver.py` (approximately 4000 lines standalone file)
-
-**Communicates with `card.py` via subprocess, not import.** Reason is that ML dependencies (torch / CLIP / opencv) are installed in a separate venv, isolated from the main program's venv.
-
-See [`hcaptcha-solver.md`](hcaptcha-solver.md) for details.
-
-#### Others
-
-- **`hcaptcha_bridge_helper.py`**: CLI tool that, after connecting to hCaptcha bridge, allows manual screenshot / click / submit operations for debugging
-- **`local_mock_gateway.py`**: Local HTTP mock server that simulates Stripe state machine (challenge_pass_then_decline / challenge_failed / no_3ds_card_declined)
-- **`retry_house_decline.py`**: Retry wrapper specialized for replaying "direct decline" rather than "entering challenge"
-
-### `CTF-reg/` —— ChatGPT Registration Subsystem
-
-Invoked by `card.py::auto_register`, registers ChatGPT account from scratch and obtains access_token.
-
-| File | Responsibility |
-|---|---|
-| `browser_register.py` | Camoufox real browser registration main path, passes Cloudflare Turnstile |
-| `auth_flow.py` | Pure HTTP registration path, fallback (incomplete coverage) |
-| `sentinel.py` | OpenAI Sentinel PoW token generation (browser fingerprint simulation + SHA-3) |
-| `mail_provider.py` | catch-all mailbox generation + delegate KV to fetch OTP |
-| `cf_kv_otp_provider.py` | Read OTP from CF KV written by worker (replaces IMAP) |
-| `http_client.py` | HTTP client factory, prioritizes curl_cffi for TLS fingerprinting |
-| `config.py` | dataclass configuration definitions |
-
-### `pipeline.py` —— Orchestrator
-
-Chains `CTF-reg/` and `CTF-pay/` together, exposing four modes externally:
-
-| Mode | Entry Function |
-|---|---|
-| Single run | `pipeline()` |
-| Batch parallel | `batch()` |
-| Self-dealing | `self_dealer()` |
-| Daemon persistent | `daemon()` |
-
-See [`operating-modes.md`](operating-modes.md) for details.
+    H --> I[可选: 推 gpt-team /<br/>CPA / 其他下游]
+```
 
 ---
 
-## Protocol Pipeline Details
+## 文件组织
 
-### Stripe Checkout Complete Pipeline```
+```
+Gpt-Agreement-Payment/
+├── pipeline.py                     # 编排器：单次 / 批量 / daemon / self-dealer
+├── CTF-pay/                        # Stripe + PayPal 协议重放
+│   ├── card.py                     # 主程序，约 8000 行
+│   ├── hcaptcha_auto_solver.py     # 视觉求解（VLM + CLIP + Playwright）
+│   ├── hcaptcha_bridge_helper.py   # 交互式调试工具
+│   ├── local_mock_gateway.py       # Stripe 状态机本地 mock
+│   ├── retry_house_decline.py      # 拒卡终态重试包装
+│   └── config.*.json               # 模板入仓，运行时配置 gitignored
+├── CTF-reg/                        # ChatGPT 注册子系统
+│   ├── browser_register.py         # Camoufox 真浏览器注册
+│   ├── auth_flow.py                # 纯 HTTP 注册（备用）
+│   ├── sentinel.py                 # OpenAI Sentinel PoW token
+│   ├── mail_provider.py            # 生成 catch-all 邮箱 + 委托 cf_kv_otp_provider 取 OTP
+│   ├── cf_kv_otp_provider.py       # 从 Cloudflare KV 读 OTP（worker 写入）
+│   ├── http_client.py              # curl_cffi / requests 工厂
+│   └── config.py                   # dataclass 配置定义
+├── docs/                           # 详细文档
+└── output/                         # 运行时产物（gitignored）
+    ├── webui.db                  # SQLite runtime store
+    ├── SQLite runtime_meta[daemon_state]
+    └── logs/
+```
+
+---
+
+## 子系统
+
+### `CTF-pay/` —— 支付协议重放主程序
+
+#### `card.py`（约 8000 行单文件）
+
+故意做成单文件大程序，按功能分区而不是拆模块。原因：
+
+- 协议链路是单条线，拆模块会增加跨文件跳转成本
+- 大量本地状态在阶段间传递，拆开后参数列表会很难看
+- 单文件易于做整体阅读和定位
+
+主要分区：
+
+| 分区 | 大致行号 | 内容 |
+|---|---|---|
+| 配置加载 | 200–600 | `load_config()`、JSON 校验、CLI 解析 |
+| HTTP 客户端 | 600–1100 | curl_cffi 包装、TLS 指纹、代理 |
+| Stripe 协议 | 1100–3000 | init / lookup / confirm / 3DS / poll |
+| ChatGPT auth | 3000–4500 | session 管理、access_token 刷新 |
+| Camoufox | 4500–6000 | PayPal 浏览器流程、二次登录 OAuth |
+| 异常 + 主入口 | 6000–8000 | 异常分类、daemon 钩子、命令入口 |
+
+#### `hcaptcha_auto_solver.py`（约 4000 行独立文件）
+
+**和 `card.py` 通过 subprocess 通信，不是 import。** 原因是 ML 依赖（torch / CLIP / opencv）装在独立 venv，跟主程序的 venv 隔离。
+
+详见 [`hcaptcha-solver.md`](hcaptcha-solver.md)。
+
+#### 其他
+
+- **`hcaptcha_bridge_helper.py`**：CLI 工具，连 hCaptcha bridge 后允许人肉 截图 / 点击 / 提交，调试用
+- **`local_mock_gateway.py`**：本地 HTTP mock 服务器，模拟 Stripe 状态机（challenge_pass_then_decline / challenge_failed / no_3ds_card_declined）
+- **`retry_house_decline.py`**：包装重试器，专门刷"直接终态拒卡"而非"进 challenge"
+
+### `CTF-reg/` —— ChatGPT 注册子系统
+
+被 `card.py::auto_register` 拉起，从零注册 ChatGPT 账号并拿到 access_token。
+
+| 文件 | 职责 |
+|---|---|
+| `browser_register.py` | Camoufox 真浏览器注册主路径，过 Cloudflare Turnstile |
+| `auth_flow.py` | 纯 HTTP 注册路径，备用（覆盖率不全） |
+| `sentinel.py` | OpenAI Sentinel PoW token 生成（浏览器指纹模拟 + SHA-3） |
+| `mail_provider.py` | catch-all 邮箱生成 + 委托 KV 取 OTP |
+| `cf_kv_otp_provider.py` | 从 CF KV 读 worker 写入的 OTP（替代 IMAP） |
+| `http_client.py` | HTTP 客户端工厂，优先 curl_cffi 做 TLS 指纹 |
+| `config.py` | dataclass 配置定义 |
+
+### `pipeline.py` —— 编排器
+
+把 `CTF-reg/` 和 `CTF-pay/` 串起来，对外暴露四种模式：
+
+| 模式 | 入口函数 |
+|---|---|
+| 单次 | `pipeline()` |
+| 批量并行 | `batch()` |
+| 自产自销 | `self_dealer()` |
+| Daemon 常驻 | `daemon()` |
+
+详见 [`operating-modes.md`](operating-modes.md)。
+
+---
+
+## 协议链路细节
+
+### Stripe Checkout 完整链路
+
+```
 init
  → elements/sessions
    → consumers/sessions/lookup
-     → address / tax_region update
+     → 地址 / tax_region 更新
        → confirm
-         (inline_payment_method_data or shared_payment_method mode)
+         (inline_payment_method_data 或 shared_payment_method 模式)
          → 3ds2/authenticate
            → poll
-```# Easy pitfalls to avoid:
+```
 
-- `setatt_` / `source` having a value does not mean success, it only means we obtained the 3DS authenticate source
-- `state = challenge_required` and `ares.transStatus = C` means **the browser side needs to continue completing the challenge**, not a dead card
-- Only after the browser truly completes the challenge will the subsequent intent / setup_intent status progress
+容易踩的点：
 
-### PayPal billing agreement complete flow```
-B1: Enter protocol authorization page (Stripe redirect)
- → B-DDC: Device fingerprint collection (including possible DataDome slider)
-   → B2: Email + password login
-     → B3: Protocol authorization consent
-       → B6: hermes path
-         → B7: funding selection
-           → B8: redirect back to Stripe
-```DataDome slider appears at B-DDC or B6. Daemon mode has automatic dragging (see [`daemon-mode.md`](daemon-mode.md)).
+- `setatt_` / `source` 有值不代表成功，只是拿到了 3DS authenticate 的 source
+- `state = challenge_required` 且 `ares.transStatus = C` 表示**需要浏览器侧继续完成 challenge**，不是废卡
+- 只有浏览器把 challenge 真做完，后面的 intent / setup_intent 状态才会推进
 
-### Codex OAuth + PKCE Secondary Login
+### PayPal billing agreement 完整链路
 
-After successful payment, start a new Camoufox instance and open the Codex authorize URL:```
+```
+B1: 进协议授权页（Stripe redirect）
+ → B-DDC: 设备指纹采集（含 DataDome 滑块可能性）
+   → B2: 邮箱 + 密码登录
+     → B3: 协议授权同意
+       → B6: hermes 路径
+         → B7: funding 选择
+           → B8: redirect 回 Stripe
+```
+
+DataDome 滑块会在 B-DDC 或 B6 出现，daemon 模式有自动拖拽（看 [`daemon-mode.md`](daemon-mode.md)）。
+
+### Codex OAuth + PKCE 二次登录
+
+支付成功后启动新 Camoufox 实例，打开 Codex authorize URL：
+
+```
 GET https://auth.openai.com/oauth/authorize
   ?client_id=YOUR_OPENAI_CODEX_CLIENT_ID
   &redirect_uri=http://localhost:1455/auth/callback
   &codex_cli_simplified_flow=true
   &code_challenge=<PKCE>
   &state=<random>
-```# Process Flow:
+```
 
-1. Enter email + password
-2. May trigger email OTP (CF Email Worker → KV, millisecond-level storage)
-3. Click Continue on Codex consent page
-4. Playwright route intercepts `localhost:1455` callback, extracts `code`
-5. POST `/oauth/token` with `code_verifier` → obtain `refresh_token`
+走流程：
 
----
-
-## Exception Classification```python
-# Core exceptions defined in CTF-pay/card.py
-CheckoutSessionInactive     # Stripe session became inactive
-ChallengeReconfirmRequired  # hCaptcha result expired
-FreshCheckoutAuthError      # ChatGPT side credential / account issue
-DatadomeSliderError         # PayPal DataDome slider solving failed
-WebshareQuotaExhausted      # Webshare proxy replacement quota exhausted
-```For each exception's recovery strategy, see [`debugging.md`](debugging.md#common-exceptions).
+1. 填邮箱 + 密码
+2. 可能触发邮箱 OTP（CF Email Worker → KV，毫秒级落库）
+3. Codex consent 页点 Continue
+4. Playwright route 拦 `localhost:1455` callback，提取 `code`
+5. POST `/oauth/token` with `code_verifier` → 拿到 `refresh_token`
 
 ---
 
-## Data Flow
+## 异常分类
+
+```python
+# CTF-pay/card.py 里定义的核心异常
+CheckoutSessionInactive     # Stripe session 失活
+ChallengeReconfirmRequired  # hCaptcha 结果失效
+FreshCheckoutAuthError      # ChatGPT 侧凭证 / 账号问题
+DatadomeSliderError         # PayPal DataDome 滑块解算失败
+WebshareQuotaExhausted      # Webshare 替换代理配额耗尽
+```
+
+每种异常的恢复策略看 [`debugging.md`](debugging.md#常见异常)。
+
+---
+
+## 数据流
 
 ### `output/webui.db`
 
-Runtime account / payment / OAuth status are stored in SQLite database `output/webui.db`. Main tables include:
+运行时账号 / 支付 / OAuth 状态都存放在 SQLite 数据库 `output/webui.db` 中。主要表包括：
 
-- `registered_accounts`: Complete credentials of successfully registered accounts (`password` / `access_token` / `session_token` / `device_id` / cookies, etc.)
-- `pipeline_results`: Result summary of pipeline single / batch / self-dealer runs
-- `card_results`: Payment end state and field-filling results of `card.py`
-- `oauth_status`: OAuth state machine during free-only / RT maintenance
+- `registered_accounts`：注册成功账号的完整凭证（`password` / `access_token` / `session_token` / `device_id` / cookies 等）
+- `pipeline_results`：pipeline 单次 / 批量 / self-dealer 的结果摘要
+- `card_results`：`card.py` 的支付终态和补字段结果
+- `oauth_status`：free-only / RT 维护时的 OAuth 状态机
 
-> This is runtime data; JSONL is no longer used as primary storage.
+> 这部分是运行时数据，不再使用 JSONL 作为主存储。
 
 ### `SQLite runtime_meta[daemon_state]`
 
-State snapshot of daemon mode (for resuming after restart):```json
+daemon 模式的状态快照（重启续跑用）：
+
+```json
 {
   "started_at": "2026-04-27T03:14:22Z",
   "total_attempts": 761,
@@ -188,17 +216,21 @@ State snapshot of daemon mode (for resuming after restart):```json
   "zone_ip_rotations": 0,
   "last_stats": { "total_active": 44, "usable": 38, "no_invite_permission": 5 }
 }
-```## Boundaries with External Systems
+```
 
-| System | Function | Required |
+---
+
+## 跟外部系统的边界
+
+| 系统 | 作用 | 必需性 |
 |---|---|---|
-| **OpenAI** | Register + login to ChatGPT, obtain OAuth refresh_token | ✅ Required |
-| **Stripe** | Checkout session flow | ✅ Required |
-| **PayPal** | Payment settlement | ✅ (unless using pure card payment) |
-| **Cloudflare** | Catch-all email subdomains, Turnstile verification during registration | ✅ Required |
-| **Captcha platform** (compatible with createTask/getTaskResult protocol) | Passive captcha + fallback | Optional (browser passive captcha takes priority, platform serves as fallback only) |
-| **Webshare** (or custom proxy) | Exit IP | ✅ Required |
-| **VLM endpoint** | hCaptcha solving | Optional (residential/pseudo-residential exit IPs typically don't trigger it; falls back to CLIP without VLM) |
-| **gpt-team / CPA** | Push to downstream management system | Optional |
+| **OpenAI** | 注册 + 登录 ChatGPT，拿 OAuth refresh_token | ✅ 必需 |
+| **Stripe** | Checkout session 链路 | ✅ 必需 |
+| **PayPal** | 支付结算 | ✅（除非用纯卡支付） |
+| **Cloudflare** | catch-all 邮箱子域、注册时过 Turnstile | ✅ 必需 |
+| **打码平台**（兼容 createTask/getTaskResult 协议） | passive captcha + 兜底 | 可选（浏览器 passive captcha 优先，平台仅作兜底） |
+| **Webshare**（或自有代理） | 出口 IP | ✅ 必需 |
+| **VLM endpoint** | hCaptcha 求解 | 可选（家宽 / 伪家宽出口通常不触发；无 VLM 时降级到 CLIP） |
+| **gpt-team / CPA** | 推下游管理系统 | 可选 |
 
-All boundaries can be toggled or swapped in config.
+边界都在 config 里可关 / 可换。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,18 +1,24 @@
-# Configuration Reference
+# 配置参考
 
-[← Back to README](../README.md)
+[← 回到 README](../README.md)
 
-The repository only ships `*.example.json` templates. You need to copy a real configuration file (gitignored) and fill in the values yourself.```bash
+仓库里只 ship `*.example.json` 模板，真实配置（gitignored）需要自己拷一份填值。
+
+```bash
 cp CTF-pay/config.paypal.example.json       CTF-pay/config.paypal.json
 cp CTF-reg/config.paypal-proxy.example.json CTF-reg/config.paypal-proxy.json
 cp CTF-reg/config.example.json              CTF-reg/config.noproxy.json
-```---
+```
 
-## `CTF-pay/config.paypal.json` — Main Configuration
+---
 
-The overall configuration for the payment side. The daemon mode also uses this same file.
+## `CTF-pay/config.paypal.json` — 主配置
 
-### `team_system` —— Push downstream gpt-team system (optional)```json
+支付侧的总配置。daemon 模式用的也是这一个文件。
+
+### `team_system` —— 推下游 gpt-team 系统（可选）
+
+```json
 "team_system": {
   "enabled": false,
   "base_url": "http://127.0.0.1:3000",
@@ -21,14 +27,18 @@ The overall configuration for the payment side. The daemon mode also uses this s
   "timeout_s": 60,
   "domain_cooldown_hours": 24
 }
-```| Field | Meaning |
-|---|---|
-| `enabled` | Disable to stop pushing downstream |
-| `base_url` | gpt-team backend address |
-| `username` / `password` | Account credentials for logging into gpt-team |
-| `domain_cooldown_hours` | Domain cooldown duration after `invite=no_permission` |
+```
 
-### `daemon` —— Daemon mode parameters```json
+| 字段 | 含义 |
+|---|---|
+| `enabled` | 关掉就不推下游 |
+| `base_url` | gpt-team 后端地址 |
+| `username` / `password` | 登 gpt-team 的账号 |
+| `domain_cooldown_hours` | `invite=no_permission` 后的域冷却时长 |
+
+### `daemon` —— 常驻模式参数
+
+```json
 "daemon": {
   "target_ok_accounts": 80,
   "usage_pool": "recovery",
@@ -41,19 +51,23 @@ The overall configuration for the payment side. The daemon mode also uses this s
   "gpt_team_db_path": "/path/to/gpt-team/backend/db/database.sqlite",
   "cf_cleanup_every_n_runs": 30
 }
-```| Field | Meaning |
-|---|---|
-| `target_ok_accounts` | Target capacity of the account pool; run pipeline if not reached |
-| `poll_interval_s` | How often to check capacity |
-| `rate_limit.per_hour / per_day` | Maximum runs per hour / per day (0 = unlimited) |
-| `max_consecutive_failures` | Cooldown after N consecutive failures |
-| `consecutive_fail_cooldown_s` | Cooldown duration after failures |
-| `jitter_before_run_s [min, max]` | Random jitter before each run |
-| `seat_limit` | Team invitation limit per Team when self-dealing |
-| `gpt_team_db_path` | Path to directly read gpt-team database for CF cleanup |
-| `cf_cleanup_every_n_runs` | Frequency of CF DNS dead subdomain cleanup |
+```
 
-### `webshare` — Proxy API Configuration```json
+| 字段 | 含义 |
+|---|---|
+| `target_ok_accounts` | 补号池目标容量，达不到就跑 pipeline |
+| `poll_interval_s` | 多久查一次容量 |
+| `rate_limit.per_hour / per_day` | 每小时 / 每天最多跑几次（0 = 无限） |
+| `max_consecutive_failures` | 连续 N 次失败后冷却 |
+| `consecutive_fail_cooldown_s` | 失败冷却时长 |
+| `jitter_before_run_s [min, max]` | 每次跑前的随机抖动 |
+| `seat_limit` | self-dealer 时单 Team 邀请上限 |
+| `gpt_team_db_path` | 直接读 gpt-team 数据库的路径，CF 清理用 |
+| `cf_cleanup_every_n_runs` | CF DNS 死子域清理频率 |
+
+### `webshare` —— 代理 API 配置
+
+```json
 "webshare": {
   "enabled": true,
   "api_key": "YOUR_WEBSHARE_API_KEY",
@@ -64,17 +78,21 @@ The overall configuration for the payment side. The daemon mode also uses this s
   "gost_listen_port": 18898,
   "sync_team_proxy": true
 }
-```| Field | Meaning |
-|---|---|
-| `api_key` | Key obtained from Webshare console |
-| `refresh_threshold` | Number of consecutive `no_invite_permission` triggers to rotate IP |
-| `no_rotation_cooldown_s` | Cooldown duration after quota exhaustion |
-| `lock_country` | Lock country (US is relatively stable) |
-| `zone_rotate_after_ip_rotations` | Switch zone after rotating IP this many times within the same zone |
-| `gost_listen_port` | Local gost relay listening port |
-| `sync_team_proxy` | Whether to sync gpt-team global proxy settings after IP rotation |
+```
 
-### `cpa` — Push downstream CPA server (optional)```json
+| 字段 | 含义 |
+|---|---|
+| `api_key` | Webshare 控制台拿到的 key |
+| `refresh_threshold` | 连续多少次 `no_invite_permission` 触发换 IP |
+| `no_rotation_cooldown_s` | 配额耗尽后的冷却时长 |
+| `lock_country` | 锁国（US 比较稳） |
+| `zone_rotate_after_ip_rotations` | 同 zone 内换几次 IP 后切 zone |
+| `gost_listen_port` | 本地 gost 中继监听的端口 |
+| `sync_team_proxy` | 换 IP 后是否同步 gpt-team 全局代理设置 |
+
+### `cpa` —— 推下游 CPA 服务器（可选）
+
+```json
 "cpa": {
   "enabled": true,
   "base_url": "https://your-cpa-host/api",
@@ -83,29 +101,37 @@ The overall configuration for the payment side. The daemon mode also uses this s
   "plan_tag": "team",
   "timeout_s": 20
 }
-````oauth_client_id` is the OAuth client_id of Codex CLI — the specific value can be seen from the Codex CLI source code.
+```
 
-### `proxies` — Global Proxy Pool```json
+`oauth_client_id` 是 Codex CLI 的 OAuth client_id —— 从 Codex CLI 源码可以看到具体值。
+
+### `proxies` —— 全局代理池
+
+```json
 "proxies": {
   "enabled": true,
   "rotation": "random",
   "list": ["socks5://127.0.0.1:18898"]
 }
-```| Field | Meaning |
+```
+
+| 字段 | 含义 |
 |---|---|
-| `rotation` | `random` / `static` / `lru` (rotate by "least recently used") |
-| `list` | Fill multiple entries when using multiple proxies |
+| `rotation` | `random` / `static` / `lru`（按"最近使用"轮换） |
+| `list` | 多代理时填多条 |
 
 ### `paypal` / `cards` / `captcha` / `fresh_checkout` / `runtime`
 
-For the remaining fields, see the comments in the template and [`hcaptcha-solver.md`](hcaptcha-solver.md) / [`operating-modes.md`](operating-modes.md).
+剩下的字段含义详见模板里的注释和 [`hcaptcha-solver.md`](hcaptcha-solver.md) / [`operating-modes.md`](operating-modes.md)。
 
 ---
 
-## `CTF-reg/config.paypal-proxy.json` — Registration-side configuration```json
+## `CTF-reg/config.paypal-proxy.json` — 注册侧配置
+
+```json
 {
   "mail": {
-    "_comment": "OTP goes through CF Email Worker → KV, credentials are in SQLite runtime_meta[secrets], only configure catch-all domain here",
+    "_comment": "OTP 走 CF Email Worker → KV，凭证在 SQLite runtime_meta[secrets]，这里只配 catch-all 域名",
     "catch_all_domain": "subdomain.example.com",
     "catch_all_domains": ["subdomain.example.com"],
     "auto_provision": {
@@ -123,12 +149,14 @@ For the remaining fields, see the comments in the template and [`hcaptcha-solver
   "captcha": { "client_key": "YOUR_CAPTCHA_API_KEY" },
   "proxy": "socks5://USER:PASS@PROXY_HOST:PORT"
 }
-```> **OTP Reception: CF Email Worker → KV** (no longer pulling QQ mailbox via IMAP)
+```
+
+> **OTP 接收：CF Email Worker → KV**（不再用 IMAP 拉 QQ 邮箱）
 >
-> OTP emails for registration and PayPal login are routed through Cloudflare Email Routing → `otp-relay`
-> Worker → KV storage (millisecond-level, see [`scripts/setup_cf_email_worker.py`](../scripts/setup_cf_email_worker.py) one-click deployment + [`scripts/otp_email_worker.js`](../scripts/otp_email_worker.js)).
+> 注册和 PayPal 登录的 OTP 邮件都经 Cloudflare Email Routing → `otp-relay`
+> Worker → KV 落库（毫秒级，见 [`scripts/setup_cf_email_worker.py`](../scripts/setup_cf_email_worker.py) 一键部署 + [`scripts/otp_email_worker.js`](../scripts/otp_email_worker.js)）。
 >
-> After one-time setup, OTP credentials are written to `SQLite runtime_meta[secrets]`:
+> 一次性配好后，OTP 凭证写到 `SQLite runtime_meta[secrets]`：
 >
 > ```json
 > {
@@ -142,49 +170,54 @@ For the remaining fields, see the comments in the template and [`hcaptcha-solver
 > }
 > ```
 >
-> You can also temporarily override with environment variables `CF_API_TOKEN` / `CF_ACCOUNT_ID` / `CF_OTP_KV_NAMESPACE_ID`.
+> 也可以用环境变量 `CF_API_TOKEN` / `CF_ACCOUNT_ID` / `CF_OTP_KV_NAMESPACE_ID`
+> 临时覆盖。
 
-`mail.auto_provision` is a multi-zone domain pool configuration:
+`mail.auto_provision` 是多 zone 域池配置：
 
-| Field | Meaning |
+| 字段 | 含义 |
 |---|---|
-| `enabled` | Enable auto-provisioning of new subdomains |
-| `zone_names` | List of candidate zones; switch to the next one when the first is exhausted |
-| `min_available` | Minimum number of available subdomains in the pool; create new ones if below this |
-| `min_segs` / `max_segs` | Number of segments in a subdomain (e.g., `aaa.bbb.zone` has 2 segments) |
-| `min_seg_len` / `max_seg_len` | Length of each segment |
-| `dns_propagation_s` | Wait time for DNS propagation after creating a new subdomain |
+| `enabled` | 启用自动开新子域 |
+| `zone_names` | 候选 zone 列表，第一个用完切第二个 |
+| `min_available` | 池里至少有多少个可用子域，少于就开新的 |
+| `min_segs` / `max_segs` | 子域有几段（如 `aaa.bbb.zone` 是 2 段） |
+| `min_seg_len` / `max_seg_len` | 每段长度 |
+| `dns_propagation_s` | 开新子域后等多久 DNS 生效 |
 
 ---
 
 ## VLM endpoint
 
-The hCaptcha solver's VLM is configured via environment variables, defaulting to OpenAI connection:```bash
+hCaptcha 求解器的 VLM 通过环境变量配置，默认连 OpenAI：
+
+```bash
 export CTF_VLM_BASE_URL="https://api.openai.com/v1"
 export CTF_VLM_API_KEY="sk-..."
 export CTF_VLM_MODEL="gpt-4o"
-```You can also connect to any OpenAI-compatible endpoint (self-hosted OpenAI proxy / local vLLM / other vendor gateways).
+```
+
+也可以连任何 OpenAI 兼容的 endpoint（自建的 OpenAI proxy / 本地 vLLM / 其他厂商网关）。
 
 ---
 
-## Tuning Environment Variables
+## 调优环境变量
 
-| Variable | Default | Effect |
+| 变量 | 默认 | 作用 |
 |---|---|---|
-| `SKIP_SIGNUP_CODEX_RT` | `1` | Skip known-failing OAuth paths during signup phase, saves ~30s/account |
-| `SKIP_HERMES_FAST_PATH` | `1` | Skip PayPal endpoints that return `genericError` for non-browser sessions, saves 5–10s/payment |
-| `CTF_VLM_BASE_URL` | `https://api.openai.com/v1` | hCaptcha solver's VLM endpoint |
-| `CTF_VLM_API_KEY` | (empty) | VLM bearer token |
-| `CTF_VLM_MODEL` | `gpt-4o` | VLM model ID |
+| `SKIP_SIGNUP_CODEX_RT` | `1` | 跳过 signup 阶段已知失败的 OAuth 路径，省 ~30s/账号 |
+| `SKIP_HERMES_FAST_PATH` | `1` | 跳过 PayPal 对非浏览器 session 返 `genericError` 的端点，省 5–10s/支付 |
+| `CTF_VLM_BASE_URL` | `https://api.openai.com/v1` | hCaptcha solver 的 VLM endpoint |
+| `CTF_VLM_API_KEY` | （空） | VLM bearer token |
+| `CTF_VLM_MODEL` | `gpt-4o` | VLM 模型 ID |
 
 ---
 
-## Config Loading Priority
+## 配置加载优先级
 
-Lookup order for `load_config()`:
+`load_config()` 的查找顺序：
 
-1. Command line `--config <path>` explicitly specified
-2. Default `CTF-pay/config.auto.json`
-3. Fallback to template `CTF-pay/config.paypal.example.json` (read-only)
+1. 命令行 `--config <path>` 显式指定
+2. 默认 `CTF-pay/config.auto.json`
+3. fallback 到模板 `CTF-pay/config.paypal.example.json`（只读）
 
-Environment variables override config with higher priority, allowing temporary parameter adjustments without modifying files.
+环境变量覆盖比 config 优先级高，可以临时调参不用改文件。

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -1,150 +1,172 @@
-# Daemon Self-Healing Chain
+# Daemon 自愈链
 
-[← Back to README](../README.md)
+[← 回到 README](../README.md)
 
-Daemon is designed with the goal of "unattended operation for weeks". All twelve self-healing loops are failure modes encountered in practice, not invented ones.
+Daemon 是按"无人值守跑数周"的目标设计的。十二路自愈环全是实战里遇到过的失败模式，不是想出来的。
 
 ---
 
-## Start / Stop / View Status```bash
-# Run in background (recommended)
+## 启动 / 停止 / 看状态
+
+```bash
+# 后台跑（推荐）
 (nohup xvfb-run -a python3 -u pipeline.py --config CTF-pay/config.paypal.json --paypal --daemon \
     > output/logs/daemon-$(date +%Y%m%d-%H%M%S).log 2>&1 &)
 
-# Follow logs
+# 跟日志
 tail -f output/logs/daemon-*.log
 
-# Check status
+# 看状态
 cat SQLite runtime_meta[daemon_state] | jq .
 
-# Graceful stop (finish current cycle before exiting)
+# 优雅停（跑完当前周期再退）
 pkill -TERM -f "pipeline.*--daemon"
 
-# Force kill
+# 强杀
 pkill -9 -f "pipeline.*--daemon"
 pkill -9 -f camoufox-bin
 pkill -9 -f browser_register
 for pid in $(pgrep Xvfb); do kill -9 $pid; done
-```---
-
-## Work Cycle```
-loop:
-    sleep poll_interval_s
-
-    if rate_limit is throttled:
-        continue
-
-    usable = query gpt-team DB (!isBanned && !isDisabled && !noInvitePermission && !expired && seat not full)
-
-    if usable >= target_ok_accounts:
-        continue   # full, check again next round
-
-    try:
-        ensure_gost_alive()         # watchdog
-        cleanup_temp_leftovers()    # /tmp orphans
-        if CF cleanup needed:
-            cleanup_dead_cf()
-        run_pipeline()
-        clear self-healing flag (if invite=ok)
-    except:
-        route to corresponding self-healing branch based on exception type
-        accumulate consecutive_failures, enter cooldown if threshold exceeded
-```---
-
-## 12-Path Self-Healing Loop
-
-| Trigger | Detection | Recovery |
-|---|---|---|
-| **DataDome Slider** | `[B-DDC]` / `[B6]` iframe slider DOM appears | Playwright uses `smoothstep` easing + random jitter to simulate human dragging |
-| **PayPal Pre-filled Email** | Email step `<input disabled value="...">` | Skip input, click Next directly to password step |
-| **Consecutive `no_invite_permission`** | `webshare.refresh_threshold` (default 2) | Webshare API rotate IP → switch gost upstream → sync downstream proxies |
-| **IP Rotation Exhausted in Zone** | `zone_rotate_after_ip_rotations` (default 2) | Switch active CF zone, next provision uses another zone |
-| **Webshare Quota Depleted** | HTTP 402 / 429 | Mark `webshare_rotation_disabled`, enter `no_rotation_cooldown_s` (default 3h) cooldown |
-| **`invite=ok` Self-Healing** | One successful registration | Clear `ip_no_perm_streak` + `zone_ip_rotations` + `webshare_rotation_disabled` |
-| **`/tmp` Orphan Cleanup** | Daemon startup + after each pipeline run | Reclaim `chatgpt_reg_*` Camoufox profiles / `xvfb-run.*` directories older than 30 minutes |
-| **CF DNS Quota (Free 200/zone)** | Every `cf_cleanup_every_n_runs` runs (default 30) | Diff `gpt-team` DB against current CF records, delete banned/disabled/expired/orphan records |
-| **Multi-Zone Quota Fallback** | CF returns `400 quota exceeded` | Auto-try next zone in `zone_names` |
-| **CPA Auto-Import** | Payment success | Refresh OAuth token → `POST /v0/management/auth-files` push to CPA server |
-| **gost Relay Down** | Listen port unbound | Kill process, re-pull Webshare proxy, restart relay |
-| **OAuth `add-phone` Wall** | Free account second login redirected to `/add-phone` | Log and skip |
+```
 
 ---
 
-## Detailed Branches
+## 工作循环
 
-### 1. DataDome Slider Auto-Dragging
+```
+loop:
+    sleep poll_interval_s
 
-PayPal has a chance of showing DataDome slider during B-DDC stage (device fingerprinting) and B6 stage (hermes). The daemon auto-drags after detecting slider DOM:```python
-# Simplified logic
+    if rate_limit 卡了:
+        continue
+
+    usable = 查 gpt-team DB（!isBanned && !isDisabled && !noInvitePermission && !expired && seat 未满）
+
+    if usable >= target_ok_accounts:
+        continue   # 满了，下一轮再看
+
+    try:
+        ensure_gost_alive()         # 看门狗
+        cleanup_temp_leftovers()    # /tmp 孤儿
+        if 该清 CF 了:
+            cleanup_dead_cf()
+        run_pipeline()
+        清自愈标志（如果 invite=ok）
+    except:
+        按异常类型走对应自愈分支
+        累计 consecutive_failures，超阈值进冷却
+```
+
+---
+
+## 12 路自愈环
+
+| 触发 | 检测 | 恢复 |
+|---|---|---|
+| **DataDome 滑块** | `[B-DDC]` / `[B6]` iframe 出现 slider DOM | Playwright 用 `smoothstep` 缓动 + 随机抖动模拟人类拖 |
+| **PayPal 预填邮箱** | 邮箱步骤 `<input disabled value="...">` | 跳过填写，直接点 Next 进密码步骤 |
+| **连续 `no_invite_permission`** | `webshare.refresh_threshold`（默认 2） | Webshare API 换 IP → 切 gost upstream → 同步下游代理 |
+| **zone 内 IP 轮换耗尽** | `zone_rotate_after_ip_rotations`（默认 2） | 切 active CF zone，下次 provision 走另一个 zone |
+| **Webshare 配额耗尽** | HTTP 402 / 429 | 标 `webshare_rotation_disabled`，进 `no_rotation_cooldown_s`（默认 3h）冷却 |
+| **`invite=ok` 自愈** | 一次成功的注册 | 清 `ip_no_perm_streak` + `zone_ip_rotations` + `webshare_rotation_disabled` |
+| **`/tmp` 孤儿清理** | daemon 启动 + 每轮 pipeline 跑完 | 回收 30 分钟以上的 `chatgpt_reg_*` Camoufox profile / `xvfb-run.*` 目录 |
+| **CF DNS 配额（Free 200/zone）** | 每 `cf_cleanup_every_n_runs` 轮（默认 30） | 拿 `gpt-team` DB 跟 CF 当前记录 diff，删 banned/disabled/expired/孤儿记录 |
+| **多 zone 配额 fallback** | CF 返 `400 quota exceeded` | 自动试 `zone_names` 的下一个 zone |
+| **CPA 自动导入** | 支付成功 | 刷 OAuth token → `POST /v0/management/auth-files` 推到 CPA 服务器 |
+| **gost 中继挂掉** | 监听端口没绑 | 杀进程，重新拉 Webshare 代理，重启中继 |
+| **OAuth `add-phone` 墙** | 免费账号二次登录被重定向到 `/add-phone` | 记日志跳过 |
+
+---
+
+## 详细分支
+
+### 1. DataDome 滑块自动拖拽
+
+PayPal 在 B-DDC 阶段（设备指纹采集）和 B6 阶段（hermes）有概率出现 DataDome 滑块。Daemon 检测到 slider DOM 后自动拖：
+
+```python
+# 简化版逻辑
 def _try_solve_ddc_slider(page):
-    # Find slider iframe (src contains ddc/captcha/datadome)
+    # 找 slider iframe（src 含 ddc/captcha/datadome）
     for frame in page.frames:
         if any(k in frame.url for k in ("ddc", "captcha", "datadome")):
             slider = frame.query_selector('[class*="slider"]')
             if slider:
                 box = slider.bounding_box()
-                # smoothstep easing + jitter
+                # smoothstep 缓动 + 抖动
                 animate_drag(box, distance=240, duration_ms=800, jitter=True)
                 return True
     return False
-```# Does not consume IP burn quota. Throws `DatadomeSliderError` on failure, daemon reruns current round (without switching IP).
+```
 
-### 2. Webshare API automatic IP switching```python
+不消耗 IP burn 配额。失败抛 `DatadomeSliderError`，daemon 重跑当前轮（不切 IP）。
+
+### 2. Webshare API 自动换 IP
+
+```python
 def _rotate_webshare_ip():
-    # 1. Call Webshare API to get a new proxy
+    # 1. 调 Webshare API 换一个新代理
     new_proxy = webshare.refresh_pool(country="US")
 
-    # 2. Kill local gost and start a new one pointing to the new upstream
+    # 2. 杀掉本地 gost，新起一个指向新 upstream
     _swap_gost_relay(port=18898, upstream=new_proxy)
 
-    # 3. Sync gpt-team global proxy settings
+    # 3. 同步 gpt-team 全局代理设置
     if cfg.webshare.sync_team_proxy:
         team_system.update_global_proxy(new_proxy)
-```# Trigger Conditions
+```
 
-Trigger condition: Consecutive N times (`refresh_threshold`, default 2) registration returns `no_invite_permission`.
+触发条件：连续 N 次（`refresh_threshold`，默认 2）注册返 `no_invite_permission`。
 
-### 3. Multi-zone Domain Pool Fallback
+### 3. 多 zone 域池 fallback
 
-CF Free plan has a limit of 200 DNS records per zone. Once a zone is full:```python
+CF Free plan 每 zone 200 条 DNS 记录上限。一个 zone 用满后：
+
+```python
 try:
     provisioner.set_active_zone(current_zone).provision()
 except CloudflareQuotaExceeded:
-    # Switch to the next zone
+    # 切下一个 zone
     next_zone = zone_pool.next(current_zone)
     state["current_zone"] = next_zone
     state["zone_ip_rotations"] = 0
     state["total_zone_rotations"] += 1
     provisioner.set_active_zone(next_zone).provision()
-```# Translation
+```
 
-It can also be triggered at the IP dimension: if switching through N IPs within the same zone still doesn't work (indicating the entire zone is blacklisted), move to the next zone.
+也可以是 IP 维度触发：同 zone 内换够 N 个 IP 还是不行（说明这 zone 整个被打标），切下一个 zone。
 
-### 4. CF DNS Dead Subdomain Cleanup
+### 4. CF DNS 死子域清理
 
-CF Free plan has a 200 record/zone limit. After the daemon runs for a while, it accumulates a large number of "account-banned but DNS records still exist" subdomains, consuming the quota.
+CF Free plan 200 record/zone 上限。daemon 跑一段时间后会积累大量"已封号但 DNS 记录还在"的子域，吃光配额。
 
-Run cleanup every `cf_cleanup_every_n_runs` rounds (default 30):```python
+每 `cf_cleanup_every_n_runs` 轮（默认 30）跑一次清理：
+
+```python
 def _cleanup_dead_cf_subdomains():
-    # 1. Get email addresses of banned/disabled/expired/no_invite_permission accounts from gpt-team DB
+    # 1. 拿 gpt-team DB 里 banned/disabled/expired/no_invite_permission 的账号邮箱
     dead_emails = query_dead_accounts(gpt_team_db_path)
     dead_subdomains = {e.split("@")[1] for e in dead_emails}
 
-    # 2. List all current catch-all subdomain records in CF
+    # 2. 列 CF 当前所有 catch-all 子域记录
     cf_records = provisioner.list_subdomains()
 
-    # 3. Find orphans (exist in CF but not recorded in gpt-team DB)
+    # 3. 找孤儿（CF 上有但 gpt-team DB 里没记录的）
     orphans = cf_records - all_known_subdomains_from_db()
 
-    # 4. Delete intersection + orphans
+    # 4. 删交集 + 孤儿
     to_delete = (cf_records & dead_subdomains) | orphans
     for sub in to_delete:
         provisioner.delete_record(sub)
-```One run of this step released 154 records.
+```
 
-### 5. tmpfs Orphan Cleanup
+某次跑这一步释放了 154 条记录。
 
-`/tmp` is tmpfs (RAM-backed, ~1 GB) on most distributions. Camoufox profiles that don't exit cleanly leave orphan directories. Clean up on daemon startup + after each run:```python
+### 5. tmpfs 孤儿回收
+
+`/tmp` 在大多数发行版是 tmpfs（RAM 后端，~1 GB）。Camoufox profile 跑完没退干净就会留孤儿目录。daemon 启动 + 每轮跑完都清一次：
+
+```python
 def _cleanup_temp_leftovers(max_age_s=1800):
     patterns = [
         "/tmp/chatgpt_reg_*",
@@ -156,19 +178,27 @@ def _cleanup_temp_leftovers(max_age_s=1800):
         for path in glob.glob(pat):
             if os.path.getmtime(path) < time.time() - max_age_s:
                 shutil.rmtree(path, ignore_errors=True)
-```### 6. gost Relay Watchdog
+```
 
-gost occasionally crashes on its own (OOM / network exceptions). Check at daemon startup + before each pipeline round:```python
+### 6. gost 中继看门狗
+
+gost 偶尔会自己挂（OOM / 网络异常）。daemon 启动时 + 每轮 pipeline 前都检查：
+
+```python
 def _ensure_gost_alive(port=18898):
     if not is_port_listening(port):
-        # Pull a fresh proxy from Webshare
+        # 重新从 Webshare 拉一个代理
         proxy = webshare.refresh_pool()
         _swap_gost_relay(port, proxy)
         if cfg.webshare.sync_team_proxy:
             team_system.update_global_proxy(proxy)
-```### 7. RegistrationError Classification
+```
 
-When registration fails, distinguish between **infrastructure failures** and **anti-fraud failures**:```python
+### 7. RegistrationError 分类
+
+注册失败时区分**基础设施失败**和**反欺诈失败**：
+
+```python
 INFRA_KEYWORDS = (
     "InvalidIP", "geoip", "cannot open display",
     "proxy", "socks5", "camoufox", "connection refused"
@@ -177,32 +207,38 @@ INFRA_KEYWORDS = (
 def classify_registration_error(exc):
     msg = str(exc).lower()
     if any(k in msg for k in INFRA_KEYWORDS):
-        return "infra"  # Not counted toward zone_reg_fail_streak
+        return "infra"  # 不计入 zone_reg_fail_streak
     return "domain_risk"
-```Only `domain_risk` class failures accumulate `zone_reg_fail_streak`, avoiding infrastructure jitter from triggering zone switching.
+```
 
-### 8. CPA Auto Import
+只有 `domain_risk` 类失败才累计 `zone_reg_fail_streak`，避免基础设施抖动误触发 zone 切换。
 
-Automatically push to external CPA system after successful payment:```python
+### 8. CPA 自动导入
+
+支付成功后自动推到外部 CPA 系统：
+
+```python
 def _cpa_import_after_team(record):
     rt = record["refresh_token"]
-    # Exchange RT for access_token once
+    # 用 RT 换一次 access_token
     at = exchange_codex_refresh_token(rt, client_id=cfg.cpa.oauth_client_id)
-    # Push to CPA
+    # 推 CPA
     requests.post(
         f"{cfg.cpa.base_url}/v0/management/auth-files?name={record['email']}",
         headers={"Authorization": f"Bearer {cfg.cpa.admin_key}"},
         json={"access_token": at, "refresh_token": rt, "plan_tag": cfg.cpa.plan_tag},
     )
-```# CPA host Behind CF
+```
 
-Use `curl_cffi` instead of `requests` when CPA host is behind CF, to bypass CF WAF.
+CPA host 在 CF 后面时用 `curl_cffi` 而不是 `requests`，绕 CF WAF。
 
 ---
 
-## State Persistence
+## 状态持久化
 
-`SQLite runtime_meta[daemon_state]` for resuming runs after restart:```json
+`SQLite runtime_meta[daemon_state]` 重启续跑用：
+
+```json
 {
   "started_at": "2026-04-27T03:14:22Z",
   "total_attempts": 761,
@@ -223,47 +259,59 @@ Use `curl_cffi` instead of `requests` when CPA host is behind CF, to bypass CF W
     "no_invite_permission": 5
   }
 }
-```# Process Restart and `started_at`
+```
 
-When a process restarts, `started_at` will be reset, while all other fields are preserved.
+进程重启时 `started_at` 会被重置，其他字段全部保留。
 
 ---
 
-## Rate Limiting Protection```json
+## 限流保护
+
+```json
 "daemon": {
   "rate_limit": { "per_hour": 0, "per_day": 0 },
   "max_consecutive_failures": 5,
   "consecutive_fail_cooldown_s": 1800,
   "jitter_before_run_s": [60, 180]
 }
-```| Field | Meaning |
+```
+
+| 字段 | 含义 |
 |---|---|
-| `rate_limit.per_hour / per_day` | 0 = unlimited. After setting, sleep to next window on excess |
-| `max_consecutive_failures` | Enter cooldown after N consecutive failures |
-| `consecutive_fail_cooldown_s` | Cooldown duration |
-| `jitter_before_run_s [min, max]` | Random jitter before each run to avoid detection of precise intervals |
+| `rate_limit.per_hour / per_day` | 0 = 无限。设了之后超额就 sleep 到下一窗口 |
+| `max_consecutive_failures` | 连续失败 N 次进冷却 |
+| `consecutive_fail_cooldown_s` | 冷却时长 |
+| `jitter_before_run_s [min, max]` | 每次跑前的随机抖动，避免精确间隔被识别 |
 
 ---
 
-## Debugging daemon```bash
-# Real-time log tailing
+## 调试 daemon
+
+```bash
+# 实时跟日志
 tail -f output/logs/daemon-*.log
 
-# Search for specific keywords
+# 找特定关键词
 grep -E "ROTATE|FAILED|SUCCEEDED" output/logs/daemon-*.log | tail -50
 
-# View hit rate for each IP
+# 看每个 IP 的命中率
 grep "current_proxy_ip" output/logs/daemon-*.log | sort | uniq -c
 
-# View which zone is used most
+# 看哪个 zone 用得多
 grep "current_zone" output/logs/daemon-*.log | sort | uniq -c
 
-# View anti-fraud trigger count
+# 看反欺诈触发次数
 grep -c "no_invite_permission" output/logs/daemon-*.log
-```## Weekly Trial Run Recommendations
+```
 
-- Write logs to disk files, not stdout (journal will be truncated by systemd)
-- Configure logrotate to rotate logs:```
+---
+
+## 跑数周的实测建议
+
+- 跟日志写到磁盘文件，不是 stdout（journal 会被 systemd 截断）
+- 配 logrotate 切日志：
+
+```
 # /etc/logrotate.d/Gpt-Agreement-Payment
 /path/to/Gpt-Agreement-Payment/output/logs/*.log {
     daily
@@ -272,11 +320,13 @@ grep -c "no_invite_permission" output/logs/daemon-*.log
     missingok
     notifempty
 }
-```- Set up monitoring (Prometheus / Telegram bot pulls `SQLite runtime_meta[daemon_state]`), key metrics:
-  - `total_succeeded` / `total_attempts` ratio
-  - `consecutive_failures` spike
-  - `webshare_rotation_disabled = true` lasting over 1 hour
-  - `ip_no_perm_streak` frequently jumping to 2
+```
 
-- Periodically ssh in to check `pgrep camoufox` — should be ≤ 1, more means processes didn't exit cleanly
-- `df -h /tmp`: tmpfs usage over 50% indicates orphaned files weren't cleaned, manually `rm -rf /tmp/chatgpt_reg_*`
+- 配监控（Prometheus / Telegram bot 拉 `SQLite runtime_meta[daemon_state]`），关键指标：
+  - `total_succeeded` / `total_attempts` 比例
+  - `consecutive_failures` 走高
+  - `webshare_rotation_disabled = true` 持续超过 1 小时
+  - `ip_no_perm_streak` 频繁跳到 2
+
+- 周期性 ssh 上去看 `pgrep camoufox` —— 应该 ≤ 1 个，多了说明有进程没退干净
+- `df -h /tmp`：tmpfs 用量超 50% 就是孤儿没清干净，手动 `rm -rf /tmp/chatgpt_reg_*`

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,136 +1,176 @@
-# Debug Manual
+# 调试手册
 
-[← Back to README](../README.md)
+[← 回到 README](../README.md)
 
-Follow this checklist item by item when you encounter issues.
+跑出问题时按这里的清单一项项排。
 
 ---
 
-## Log Locations```bash
-# Complete pipeline logs
+## 日志位置
+
+```bash
+# 完整 pipeline 日志
 tail -f output/logs/card.log
 
-# Daemon main logs
+# Daemon 主日志
 tail -f output/logs/daemon-*.log
 
-# hCaptcha solver output per round
+# hCaptcha solver 每轮产物
 ls -lah /tmp/hcaptcha_auto_solver_live/
 
-# PayPal browser screenshots at each stage
+# PayPal 浏览器各阶段截图
 ls -lah /tmp/paypal_*.png
 
-# Secondary OAuth login screenshots
+# 二次 OAuth 登录截图
 ls -lah /tmp/rt_*.png
 
-# Daemon status
+# Daemon 状态
 cat SQLite runtime_meta[daemon_state] | jq .
-```---
+```
 
-## Common Exceptions
+---
+
+## 常见异常
 
 ### `CheckoutSessionInactive`
 
-Stripe session has become inactive. Stripe checkout sessions expire after 24 hours by default, which can occur during long-running workflows or when the machine resumes after sleep.
+Stripe session 失活了。Stripe 的 checkout session 默认 24 小时过期，长跑流程或机器睡了一觉再跑就会撞上。
 
-**Auto Recovery**: Set `auto_refresh_on_inactive: true` in config, and `card.py` will automatically regenerate a fresh checkout to resume the workflow.```json
+**自动恢复**：config 里设 `auto_refresh_on_inactive: true`，`card.py` 会自动重新生成 fresh checkout 续跑。
+
+```json
 "fresh_checkout": {
   "auto_refresh_on_inactive": true
 }
-```### `ChallengeReconfirmRequired`
+```
 
-hCaptcha result has expired. hCaptcha tokens have a TTL (approximately 2 minutes) and will expire if there is too much delay before confirm.
+### `ChallengeReconfirmRequired`
 
-**Manual recovery**: Re-run the confirm phase.
+hCaptcha 结果失效。hCaptcha token 有 TTL（约 2 分钟），在 confirm 之前耽搁太久就会过期。
 
-**Root solution**: Don't set the daemon's `jitter_before_run_s` too long, or avoid other time-consuming operations before confirm.
+**手动恢复**：重跑 confirm 阶段。
+
+**根本解法**：调 daemon 的 `jitter_before_run_s` 不要太长，或者在 confirm 之前不要做其他耗时操作。
 
 ### `FreshCheckoutAuthError`
 
-ChatGPT side rejected your auth credentials. Possible causes:
+ChatGPT 侧拒绝你的 auth 凭证。可能原因：
 
-- `access_token` expired
-- `session_token` invalid
-- Account banned / disabled
-- Account triggered `add-phone` wall
+- `access_token` 过期
+- `session_token` 失效
+- 账号被 ban / 被禁用
+- 账号触发 `add-phone` 墙
 
-**Troubleshooting**:```python
-# Call /api/auth/session directly once to check the response
+**排错**：
+
+```python
+# 直接调一次 /api/auth/session 看响应
 import requests
 r = requests.get(
     "https://chatgpt.com/api/auth/session",
     headers={"Cookie": "__Secure-next-auth.session-token=..."}
 )
 print(r.status_code, r.json())
-```If 401 / token_invalidated → Re-register or refresh session_token.
-If 401 / account_deactivated → The account is dead, switch to another account.
+```
+
+如果是 401 / token_invalidated → 重新注册或刷新 session_token。
+如果是 401 / account_deactivated → 这号死了，换号。
 
 ### `DatadomeSliderError`
 
-Failed to solve PayPal's DataDome slider.
+PayPal 的 DataDome 滑块解算失败。
 
-**Troubleshooting**:```bash
-# Check the most recent failed screenshot
+**排错**：
+
+```bash
+# 看最近一次失败的截图
 ls -lt /tmp/paypal_ddc_*.png | head -1
 
-# Check solver decisions (if in daemon mode)
+# 看 solver 决策（如果 daemon 模式）
 grep "DatadomeSliderError" output/logs/daemon-*.log | tail -5
-```**daemon behavior**: daemon will rerun the current round without consuming IP burn quota.
+```
 
-**Manual debugging**:```python
-# Temporarily add page.pause() in card.py::_try_solve_ddc_slider to pause the browser
-# Then run with headless=False once to see what the DOM looks like
-```### `WebshareQuotaExhausted`
+**daemon 行为**：daemon 会重跑当前轮，**不**消耗 IP burn 配额。
 
-Webshare API has no available replacement proxies (monthly quota exhausted).
+**手动调试**：
 
-**daemon behavior**: Mark `webshare_rotation_disabled = true`, enter `no_rotation_cooldown_s` (default 3h) cooldown.
+```python
+# 在 card.py::_try_solve_ddc_slider 里临时加 page.pause() 暂停浏览器
+# 然后 headless=False 跑一次看 DOM 长啥样
+```
 
-**manual recovery**:```bash
-# Upgrade Webshare plan, or
-# manually modify SQLite runtime_meta[daemon_state] to set webshare_rotation_disabled to false
+### `WebshareQuotaExhausted`
+
+Webshare API 没有可用替换代理了（套餐每月配额耗尽）。
+
+**daemon 行为**：标 `webshare_rotation_disabled = true`，进 `no_rotation_cooldown_s`（默认 3h）冷却。
+
+**手动恢复**：
+
+```bash
+# 升级 Webshare 套餐，或者
+# 手动改 SQLite runtime_meta[daemon_state] 把 webshare_rotation_disabled 设 false
 jq '.webshare_rotation_disabled = false | .no_perm_cooldown_until = 0' \
    SQLite runtime_meta[daemon_state] > /tmp/state.json && \
    mv /tmp/state.json SQLite runtime_meta[daemon_state]
-```### `socks5 auth not supported`
+```
 
-Camoufox does not support socks5 with authentication. Configure a gost relay:```bash
+### `socks5 auth not supported`
+
+Camoufox 不吃带 auth 的 socks5。配 gost 中继：
+
+```bash
 gost -L=socks5://:18898 -F=socks5://USER:PASS@PROXY_HOST:PORT &
-```Change the proxy in config to `socks5://127.0.0.1:18898`. The daemon mode has a built-in gost watchdog that automatically manages this process.
+```
+
+config 里 proxy 改成 `socks5://127.0.0.1:18898`。daemon 模式有内置 gost 看门狗自动管理这个进程。
 
 ### `cannot open display`
 
-xvfb is not running or `DISPLAY` was not passed:```bash
-# Wrap with xvfb-run (recommended)
+xvfb 没起或 `DISPLAY` 没传：
+
+```bash
+# 用 xvfb-run 包一层（推荐）
 xvfb-run -a python pipeline.py ...
 
-# Or manually start Xvfb
+# 或者手动起 Xvfb
 Xvfb :99 -screen 0 1920x1080x24 &
 DISPLAY=:99 python pipeline.py ...
-```### `geoip InvalidIP` / Camoufox Error `InvalidIP`
+```
 
-Usually the gost relay is down, and Camoufox cannot get a legitimate exit IP when connecting directly.
+### `geoip InvalidIP` / Camoufox 报错 `InvalidIP`
 
-**daemon**: `_ensure_gost_alive()` will automatically detect port unbinding and restart gost.
-**Single run**: Manually restart gost:```bash
+通常是 gost 中继挂了，Camoufox 直连出去拿不到合法出口 IP。
+
+**daemon**：`_ensure_gost_alive()` 会自动检测端口失绑并重启 gost。
+**单跑**：手动重启 gost：
+
+```bash
 pkill gost
 gost -L=socks5://:18898 -F=socks5://USER:PASS@HOST:PORT &
-```## Diagnostic Commands
+```
 
-### Check How It's Running```bash
-# Overall success rate
+---
+
+## 诊断命令
+
+### 看跑得怎么样
+
+```bash
+# 总成功率
 jq -r '.total_succeeded as $s | .total_attempts as $t | "\($s)/\($t) = \($s/$t*100)%"' \
    SQLite runtime_meta[daemon_state]
 
-# Hit rate per IP
+# 每个 IP 的命中率
 grep "current_proxy_ip" output/logs/daemon-*.log | sort | uniq -c | sort -rn
 
-# Usage count per zone
+# 每个 zone 的使用次数
 grep "current_zone" output/logs/daemon-*.log | sort | uniq -c
 
-# Anti-fraud trigger count
+# 反欺诈触发次数
 grep -c "no_invite_permission" output/logs/daemon-*.log
 
-# Survival rate for the past week (requires gpt-team DB)
+# 最近一周存活率（需要 gpt-team DB）
 sqlite3 /path/to/gpt-team/db/database.sqlite \
     "SELECT
        SUM(CASE WHEN is_banned=1 THEN 1 ELSE 0 END) AS banned,
@@ -138,54 +178,72 @@ sqlite3 /path/to/gpt-team/db/database.sqlite \
        COUNT(*) AS total
      FROM gpt_accounts
      WHERE created_at > datetime('now', '-7 days')"
-```### See hCaptcha Failure Reasons```bash
-# List the most recent failures
+```
+
+### 看 hCaptcha 失败原因
+
+```bash
+# 列最近失败
 ls -lt /tmp/hcaptcha_auto_solver_live/checkcaptcha_fail_*.json | head -5
 
-# View the decision process
+# 看决策过程
 cat /tmp/hcaptcha_auto_solver_live/round_05.json | jq .
 
-# Count failed question types
+# 统计失败题型
 for f in /tmp/hcaptcha_auto_solver_live/round_*.json; do
     jq -r 'select(.result == "fail") | .prompt' "$f"
 done | sort | uniq -c | sort -rn
-```### See Where PayPal Gets Stuck```bash
-# List screenshots from each stage
+```
+
+### 看 PayPal 卡在哪
+
+```bash
+# 列各阶段截图
 ls /tmp/paypal_*.png
 
-# Stage distribution
+# 阶段分布
 ls /tmp/paypal_*.png | sed 's/.*paypal_//;s/_[0-9]*\.png//' | sort | uniq -c
-```---
-
-## Offline / Mock Debugging
-
-### Offline Playback (No Real Requests)```bash
-python CTF-pay/card.py auto --config CTF-pay/config.offline-replay.json --offline-replay
-```# Capture and Replay from `flows/`, No Internet Required. Suitable for Debugging Internal Logic in `card.py`.
-
-### Local Mock Gateway```bash
-python CTF-pay/card.py auto --config CTF-pay/config.local-mock.json --local-mock
-```# Start Local HTTP Server to Simulate Stripe State Machine
-
-You can select scenarios:
-
-- `challenge_pass_then_decline`: challenge passes but card is declined in final state
-- `challenge_failed`: challenge fails directly
-- `no_3ds_card_declined`: card is declined without entering 3DS
-
-Suitable for debugging challenge / 3DS state machine logic, no need for real cards / real proxies.
+```
 
 ---
 
-## Packet Capture Analysis```bash
-# Parse mitmproxy flows file
+## 离线 / mock 调试
+
+### 离线回放（不发真实请求）
+
+```bash
+python CTF-pay/card.py auto --config CTF-pay/config.offline-replay.json --offline-replay
+```
+
+从 `flows/` 抓包重放，不出网。适合 debug `card.py` 内部逻辑。
+
+### 本地 mock gateway
+
+```bash
+python CTF-pay/card.py auto --config CTF-pay/config.local-mock.json --local-mock
+```
+
+启本地 HTTP server 模拟 Stripe 状态机，可以选场景：
+
+- `challenge_pass_then_decline`：challenge 过了但卡终态被拒
+- `challenge_failed`：challenge 直接失败
+- `no_3ds_card_declined`：不进 3DS 直接拒卡
+
+适合 debug challenge / 3DS 状态机逻辑，不需要真实卡 / 真实代理。
+
+---
+
+## 抓包分析
+
+```bash
+# 解析 mitmproxy flows 文件
 python -c "
 from mitmproxy.io import FlowReader
 for f in FlowReader(open('flows', 'rb')).stream():
     print(f.request.method, f.request.pretty_url)
 "
 
-# Find Stripe protocol chain
+# 找 Stripe 协议链路
 python -c "
 from mitmproxy.io import FlowReader
 for f in FlowReader(open('flows', 'rb')).stream():
@@ -193,37 +251,39 @@ for f in FlowReader(open('flows', 'rb')).stream():
         print(f.request.method, f.request.pretty_url, '→', f.response.status_code)
 "
 
-# Dump body of a specific endpoint
+# dump 某个 endpoint 的 body
 python -c "
 from mitmproxy.io import FlowReader
 for f in FlowReader(open('flows', 'rb')).stream():
     if '/v1/setup_intents/' in f.request.pretty_url and 'confirm' in f.request.pretty_url:
         print(f.request.get_text())
 "
-```---
-
-## "I didn't change anything, but it suddenly stopped working"
-
-Most common causes (sorted by probability):
-
-1. **Stripe changed runtime fingerprint**: `runtime.version` / `js_checksum` / `rv_timestamp` drifted
-2. **OpenAI changed OAuth flow**: URL parameters changed, new step added
-3. **PayPal changed DOM**: selectors broke
-4. **hCaptcha released new challenge type**: solver throws `unknown_prompt`
-5. **Proxy got flagged**: switch IP
-
-Check in this order. Issues 1 and 4 are most likely already open in the issue tracker, check there first.
+```
 
 ---
 
-## Before submitting an issue
+## "我没改任何东西，但突然不工作了"
 
-Prepare the following information according to the [`bug_report.yml` template](../.github/ISSUE_TEMPLATE/bug_report.yml):
+最常见原因（按概率排序）：
 
-1. Complete stack trace (redacted)
-2. Last 50 lines of `output/logs/card.log`
-3. Last screenshot before error (`/tmp/*.png`)
+1. **Stripe 改了 runtime 指纹**：`runtime.version` / `js_checksum` / `rv_timestamp` 漂了
+2. **OpenAI 改了 OAuth 流程**：URL 参数变了、新增了一个步骤
+3. **PayPal 改了 DOM**：选择器失效
+4. **hCaptcha 出了新题型**：solver 抛 `unknown_prompt`
+5. **代理被打标**：换 IP
+
+按这个顺序排。1 和 4 在 issue 区开着的概率最大，先去看一下别人有没有遇到。
+
+---
+
+## 提 issue 之前
+
+按 [`bug_report.yml` 模板](../.github/ISSUE_TEMPLATE/bug_report.yml) 准备好以下信息：
+
+1. 完整 stack trace（脱敏后）
+2. `output/logs/card.log` 最后 50 行
+3. 出错前的最后一张截图（`/tmp/*.png`）
 4. `pip freeze | grep -E "playwright|camoufox|curl_cffi|requests"`
-5. Your run mode and command line arguments
+5. 你的运行模式和命令行参数
 
-**Redaction checklist**: Always censor logs/screenshots before posting. Redact tokens, cookies, real email addresses, IPs, and all PII.
+**脱敏检查**：贴日志 / 截图前一定先打码，token、cookie、真实邮箱、IP、PII 全部要遮。

--- a/docs/hcaptcha-solver.md
+++ b/docs/hcaptcha-solver.md
@@ -1,227 +1,279 @@
-# hCaptcha Visual Solver
+# hCaptcha 视觉求解器
 
-[← Back to README](../README.md)
+[← 回到 README](../README.md)
 
-`CTF-pay/hcaptcha_auto_solver.py` is a standalone 4000-line solver launched by `card.py` via subprocess (ML dependencies are in an isolated venv, so cannot be imported). It is universal for any hCaptcha bridge URL, not just the Stripe scenario.
+`CTF-pay/hcaptcha_auto_solver.py` 是个 4000 行的独立 solver，被 `card.py` 通过 subprocess 拉起（ML 依赖在独立 venv 里，所以不能 import）。它对任何 hCaptcha bridge URL 都通用，不只是 Stripe 这一个场景。
 
 ---
 
-## Three-Layer Decision```mermaid
+## 三层决策
+
+```mermaid
 flowchart TB
-    Start([Bridge Page Load]) --> Capture[Screenshot Current Challenge]
-    Capture --> VLM{VLM<br/>Available?}
-    VLM -->|Yes| VLMTry[Try VLM:<br/>Candidate Box → Direct Coordinates]
-    VLM -->|No| Heuristic[Heuristic Dispatcher]
-    VLMTry -->|Success| Execute[Playwright Execute<br/>Human Action Synthesis]
-    VLMTry -->|Fail| Heuristic
-    Heuristic --> Match{Match<br/>Known Type?}
-    Match -->|Yes| Solver[Run Dedicated Solver<br/>CLIP / OpenCV / Shape IoU]
-    Match -->|No| Fail([Throw unknown_prompt])
+    Start([Bridge 页面加载]) --> Capture[截图当前 challenge]
+    Capture --> VLM{VLM<br/>可用?}
+    VLM -->|是| VLMTry[试 VLM:<br/>候选框 → 直出坐标]
+    VLM -->|否| Heuristic[启发式 dispatcher]
+    VLMTry -->|成| Execute[Playwright 执行<br/>人类动作合成]
+    VLMTry -->|败| Heuristic
+    Heuristic --> Match{匹到已知<br/>题型?}
+    Match -->|是| Solver[跑专用 solver<br/>CLIP / OpenCV / shape IoU]
+    Match -->|否| Fail([抛 unknown_prompt])
     Solver --> Execute
-    Execute --> Verify{Visual Feedback<br/>Landing?}
-    Verify -->|No| Retry[Offset ±10/16px<br/>Max 9 Retries]
-    Verify -->|Yes| Submit[Submit + Listen<br/>checkcaptcha Response]
+    Execute --> Verify{视觉反馈<br/>是否落地?}
+    Verify -->|否| Retry[偏移 ±10/16px<br/>最多重试 9 次]
+    Verify -->|是| Submit[提交 + 监听<br/>checkcaptcha 响应]
     Retry --> Verify
     Submit --> Done([Pass / Fail])
-```---
+```
 
-## Layer 1 — VLM Decision (Preferred)
+---
 
-Call any `/v1/chat/completions` endpoint compatible with OpenAI protocol, send challenge image, candidate region overlay, structured JSON instructions. Two modes:
+## 第 1 层 —— VLM 决策（首选）
 
-### Candidate Box Mode
+调任何兼容 OpenAI 协议的 `/v1/chat/completions` 端点，发 challenge 图、候选区域 overlay、结构化 JSON 指令。两种模式：
 
-First use OpenCV to extract candidate click/drag targets, label them `G1`, `G2`, `S1`, `T1` on the overlay, VLM selects the ID.```json
-// The message sent to VLM looks roughly like this
+### 候选框模式
+
+先用 OpenCV 提候选点击 / 拖拽目标，标号 `G1`、`G2`、`S1`、`T1` 写到 overlay 上，VLM 选 ID。
+
+```json
+// 提示给 VLM 的 message 大致这样
 {
   "messages": [
-    {"role": "system", "content": "You are an hCaptcha solver..."},
+    {"role": "system", "content": "你是 hCaptcha 求解器..."},
     {"role": "user", "content": [
       {"type": "text", "text": "Prompt: please click on all the water travel"},
-      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},   // original image
-      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},   // overlay with ID marked
+      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},   // 原图
+      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},   // 标 ID 后的 overlay
       {"type": "text", "text": "{\"candidates\": [{\"id\": \"G1\", \"bbox\": [...]}, ...]}"}
     ]}
   ]
 }
-```VLM Returns:```json
+```
+
+VLM 返：
+
+```json
 {"action": "click", "selected_ids": ["G1", "G3"]}
 {"action": "drag",  "source_id": "S1", "target_id": "T2"}
-```### Direct Coordinate Output Mode
+```
 
-Fallback when candidate box extraction fails, VLM directly returns normalized coordinates:```json
+### 直出坐标模式
+
+候选框提取失败时降级，VLM 直接返归一化坐标：
+
+```json
 {"action": "click", "coords": [[0.31, 0.42], [0.73, 0.41]]}
 {"action": "drag",  "from": [0.2, 0.5], "to": [0.7, 0.5]}
-```### VLM Configuration
+```
 
-Through environment variables:```bash
+### VLM 配置
+
+通过环境变量：
+
+```bash
 export CTF_VLM_BASE_URL="https://api.openai.com/v1"
 export CTF_VLM_API_KEY="sk-..."
 export CTF_VLM_MODEL="gpt-4o"
-```# Or command line `--vlm-base-url` / `--vlm-api-key` / `--vlm-model` override.
+```
+
+或者命令行 `--vlm-base-url` / `--vlm-api-key` / `--vlm-model` 覆盖。
 
 ---
 
-## Layer 2 —— CLIP / OpenCV Heuristic Dispatcher
+## 第 2 层 —— CLIP / OpenCV 启发式 dispatcher
 
-Fallback path when VLM is unavailable or fails. Dedicated solver for each known challenge type:
+VLM 不可用或失败时的回退路径。每种已知题型有专用 solver：
 
-| Challenge Prompt Keywords | Solver | Method |
+| 题型 prompt 关键词 | Solver | 方法 |
 |---|---|---|
-| `water travel` / `vehicle...water` | `solve_water_travel()` | CLIP binary classification, 3×3 grid or object candidates |
-| `drag` / `complete the pair` | `solve_pair_drag()` | Color clustering localization + skeleton matching |
-| `missing piece` / `complete the image` | `solve_missing_pieces_drag()` | HSV slot detection + shape IoU |
-| `float on water` | `solve_float_on_water()` | CLIP binary classification |
-| `served hot` | `solve_hot_food()` | CLIP binary classification |
-| `hop or jump` / `hopping` | `solve_hop_animals()` | CLIP sliding window + clustering + two-stage scoring |
-| `produce heat to work` | `solve_heat_work()` | CLIP binary classification |
-| `shiny thing` | `solve_shiny_thing()` | CLIP binary classification (single choice) |
-| `kept outside` | `solve_kept_outside()` | CLIP binary classification |
-| `dissolve or melt` | `solve_dissolve_melt()` | CLIP multi-label classification |
-| `hidden under the reference object` | `solve_hidden_under_reference()` | Edge detection + connected components |
-| `complete the road` + `finish line` | `solve_road_completion()` | Edge detection + connected components |
+| `water travel` / `vehicle...water` | `solve_water_travel()` | CLIP 二分类，3×3 grid 或 object 候选 |
+| `drag` / `complete the pair` | `solve_pair_drag()` | 颜色聚类定位 source + skeleton 匹配 |
+| `missing piece` / `complete the image` | `solve_missing_pieces_drag()` | HSV 槽位检测 + shape IoU |
+| `float on water` | `solve_float_on_water()` | CLIP 二分类 |
+| `served hot` | `solve_hot_food()` | CLIP 二分类 |
+| `hop or jump` / `hopping` | `solve_hop_animals()` | CLIP 滑窗 + 聚类 + 两阶段评分 |
+| `produce heat to work` | `solve_heat_work()` | CLIP 二分类 |
+| `shiny thing` | `solve_shiny_thing()` | CLIP 二分类（单选） |
+| `kept outside` | `solve_kept_outside()` | CLIP 二分类 |
+| `dissolve or melt` | `solve_dissolve_melt()` | CLIP 多标签分类 |
+| `hidden under the reference object` | `solve_hidden_under_reference()` | 边缘检测 + 连通组件 |
+| `complete the road` + `finish line` | `solve_road_completion()` | 边缘检测 + 连通组件 |
 
 ---
 
-## Candidate Region Extraction
+## 候选区域提取
 
-Two complementary strategies, automatically selected based on image characteristics:
+两种互补策略，根据图像特征自动选择：
 
-### Grid Mode (`detect_label_grid`)
+### Grid 模式（`detect_label_grid`）
 
-For standard 3×3 hCaptcha grids. Detects 3 evenly-distributed bands through row/column pixel variance or non-white statistics. Decision thresholds:
+针对标准 3×3 hCaptcha 网格。通过行 / 列像素方差或 non-white 统计检测 3 个等分 band。判定门槛：
 
-- Coverage ≥ 72%
-- Balance ≥ 55%
+- 覆盖率 ≥ 72%
+- 均衡度 ≥ 55%
 
-Grid path is taken if both conditions are met.
+满足两条都过就走 grid 路径。
 
-### Object Mode (`_build_object_candidates_generic`)
+### Object 模式（`_build_object_candidates_generic`）
 
-Fallback for non-standard layouts. Uses Canny edge detection + connected components + morphological denoising to extract independent objects.
+非标准布局时回退。用 Canny 边缘 + 连通组件 + 形态学去噪提取独立物体。
 
 ---
 
-## Layer 3 —— Playwright Executor
+## 第 3 层 —— Playwright 执行器
 
-### Anti-Detection
+### 反检测
 
-Inject `init_script` to override:```javascript
+注入 `init_script` 覆盖：
+
+```javascript
 Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
 Object.defineProperty(navigator, 'platform', { get: () => 'Win32' });
 Object.defineProperty(navigator, 'hardwareConcurrency', { get: () => 8 });
-// + dozen other properties
-```### Human Action Synthesis
+// + 其他十几个属性
+```
 
-- **Click**: 4-point Bézier curve approximation + random delay (200–400ms)
-- **Drag**: 3-segment interpolation path with jitter at start/middle/end
-- **Pause**: Normal distribution with mean 800ms ± 300ms between operations
+### 人类动作合成
 
-### Visual Feedback Retry Loop
+- **点击**：4 点 Bézier 曲线逼近 + 随机延迟（200–400ms）
+- **拖拽**：3 段插值路径，起 / 中 / 终各加 jitter
+- **停顿**：操作间均值 800ms ± 300ms 的 normal distribution
 
-After each interaction, capture pre and post frames and calculate two metrics:```python
+### 视觉反馈重试环
+
+每次交互后抓前后帧，算两个指标：
+
+```python
 changed_pixels = np.sum(np.any(frame_after != frame_before, axis=-1))
 mean_diff = np.mean(np.abs(frame_after.astype(int) - frame_before.astype(int)))
-```Determining "landing": `changed_pixels > THRESHOLD_PIXELS` AND `mean_diff > THRESHOLD_DIFF`.
+```
 
-If not landed, **automatically retry with offset**:
+判定 "落地"：`changed_pixels > THRESHOLD_PIXELS` 且 `mean_diff > THRESHOLD_DIFF`。
 
-- Click: `±10px / ±16px` eight directions + origin point = 9 attempts
-- Drag: `5 starts × 5 ends = 25` jitter combinations
+没落地就**自动偏移重试**：
 
-### Multiple raster sources
+- 点击：`±10px / ±16px` 八方向 + 原点 = 9 次
+- 拖拽：`5 starts × 5 ends = 25` 种 jitter 组合
 
-Prioritize canvas `toDataURL()` to get the original bitmap. When canvas is blank (hCaptcha sometimes renders images to SVG), fall back to `body.screenshot()`.
+### 多 raster 源
 
-### Network monitoring
+优先 canvas `toDataURL()` 拿原始位图。canvas 空白（hCaptcha 有时把图绘到 SVG 里）时回退 `body.screenshot()`。
 
-Intercept two endpoints in the `hcaptcha.com` domain:```python
+### 网络监听
+
+拦 `hcaptcha.com` 域的两个端点：
+
+```python
 page.on("response", lambda r: ...)
-# Intercept /getcaptcha → extract prompt / ekey
-# Intercept /checkcaptcha → extract pass status
-```Extracted metadata written to `round_XX.json`.
+# 拦 /getcaptcha → 提取 prompt / ekey
+# 拦 /checkcaptcha → 提取 pass 状态
+```
+
+提取的元数据写到 `round_XX.json`。
 
 ---
 
-## Variation Retry System
+## Variation 重试体系
 
-Solver does not return a single answer, but rather an **ordered candidate sequence**:
+Solver 不返回单一答案，而是**有序候选序列**：
 
-### Click Class
+### Click 类
 
-`candidate_click_sets` sorted by CLIP confidence:
+`candidate_click_sets` 按 CLIP 置信度排序：
 
-1. **Strong set**: all tiles with confidence ≥ 0.5
-2. **Medium set**: all tiles with confidence ≥ 0.3
-3. **Individual selection**: each candidate tile submitted separately once
+1. **Strong set**：所有置信度 ≥ 0.5 的 tile
+2. **Medium set**：所有置信度 ≥ 0.3 的 tile
+3. **逐个单选**：每个候选 tile 单独提交一次
 
-### Drag Class
+### Drag 类
 
-`build_drag_target_variations()` × `build_drag_start_variations()` each generate jitter variants:
+`build_drag_target_variations()` × `build_drag_start_variations()` 各生成 jitter 变体：
 
-- Source jitter: `±5px / ±10px` five points
-- Target jitter: same five points
-- Total combinations: 5 × 5 = 25 attempts
+- Source jitter：`±5px / ±10px` 五点
+- Target jitter：同上五点
+- 总组合：5 × 5 = 25 次
 
-### Image Hash Deduplication```python
+### 图像哈希去重
+
+```python
 key = (prompt_text, hashlib.sha1(image_bytes).hexdigest())
 exhausted_variations[key].add(variation_id)
-```Failed attempts on the same problem automatically skip.
+```
 
-### Exhausted
+同题失败的方案自动跳过。
 
-All variations used up, throw:```python
+### 耗尽
+
+所有 variation 用完抛：
+
+```python
 class drag_variations_exhausted(Exception): pass
 class click_set_variations_exhausted(Exception): pass
-````card.py` triggers the daemon's "rerun current round" branch when caught.
+```
+
+`card.py` 接住后会触发 daemon 的"重跑当前轮"分支。
 
 ---
 
-## Running solver individually```bash
-# Headed mode (watch it work)
+## 单跑 solver
+
+```bash
+# 有头模式（看着它干活）
 ~/.venvs/ctfml/bin/python CTF-pay/hcaptcha_auto_solver.py \
   http://127.0.0.1:PORT/index.html --headed --timeout 300
 
-# Disable VLM, run heuristics only
+# 关 VLM，只跑启发式
 ~/.venvs/ctfml/bin/python CTF-pay/hcaptcha_auto_solver.py \
   http://127.0.0.1:PORT/index.html --no-vlm
 
-# Custom VLM
+# 自定义 VLM
 ~/.venvs/ctfml/bin/python CTF-pay/hcaptcha_auto_solver.py \
   http://127.0.0.1:PORT/index.html \
   --vlm-base-url https://api.openai.com/v1 \
   --vlm-api-key sk-xxx \
   --vlm-model gpt-4o
 
-# Let solver directly submit verify_challenge
+# 让 solver 直接提交 verify_challenge
 ~/.venvs/ctfml/bin/python CTF-pay/hcaptcha_auto_solver.py \
   http://127.0.0.1:PORT/index.html \
   --verify-url      "https://api.stripe.com/v1/setup_intents/.../verify_challenge" \
   --verify-client-secret "seti_xxx_secret_xxx" \
   --verify-key      "pk_live_xxx"
-```## Debug Artifacts
+```
 
-`--out-dir` (default `/tmp/hcaptcha_auto_solver`):
+---
 
-| File | Meaning |
+## 调试产物
+
+`--out-dir`（默认 `/tmp/hcaptcha_auto_solver`）：
+
+| 文件 | 含义 |
 |---|---|
-| `round_XX.png` | Screenshot of each round |
-| `round_XX.json` | Complete decision metadata for each round (prompt, candidate boxes, VLM response, final decision, visual feedback values) |
-| `checkcaptcha_pass_*.json` | Network monitoring snapshot of the passing attempt |
-| `checkcaptcha_fail_*.json` | Snapshot of the failed attempt |
-| `session_meta_*.json` | Overall session metadata |
+| `round_XX.png` | 每轮截图 |
+| `round_XX.json` | 每轮完整决策元数据（prompt、候选框、VLM 响应、最终决策、视觉反馈值） |
+| `checkcaptcha_pass_*.json` | 过的那次的网络监听快照 |
+| `checkcaptcha_fail_*.json` | 失败那次的快照 |
+| `session_meta_*.json` | 整个会话元信息 |
 
-Debugging a failed challenge:```bash
-# Find the most recent failure
+调试一道失败的题：
+
+```bash
+# 找最近一次失败
 ls -lt /tmp/hcaptcha_auto_solver_live/checkcaptcha_fail_*.json | head -1
 
-# View the decision process
+# 看决策过程
 cat /tmp/hcaptcha_auto_solver_live/round_05.json | jq .
-```---
+```
 
-## `card.py` Integration Method
+---
 
-`card.py` calls the solver via `subprocess`, passing the bridge URL and VLM configuration:```json
+## `card.py` 集成方式
+
+`card.py` 通过 `subprocess` 调 solver，传 bridge URL 和 VLM 配置：
+
+```json
 "browser_challenge": {
   "external_solver": {
     "enabled": true,
@@ -239,61 +291,31 @@ cat /tmp/hcaptcha_auto_solver_live/round_05.json | jq .
     }
   }
 }
-````card.py::solve_stripe_hcaptcha_in_browser()` automatically supplements the above segment when it detects that a non-invisible challenge is needed and no external_solver is explicitly configured.
+```
 
-The solver result is passed back to `card.py` through the local bridge HTTP endpoint `/result`.
+`card.py::solve_stripe_hcaptcha_in_browser()` 检测到需要非 invisible challenge 且没显式配 external_solver 时会自动补齐上面这段。
+
+solver 结果通过本地 bridge HTTP endpoint `/result` 回传给 `card.py`。
 
 ---
 
-## Extending New Challenge Types
+## 扩展新题型
 
-Three steps:
+三步：
 
-1. Write a matching function:```python
+1. 写匹配函数：
+
+```python
 def is_carry_things_prompt(prompt: str) -> bool:
     p = prompt.lower()
     return "carry" in p and "things" in p
-```# 2. Write the Solution Function:
-
-```python
-def solve(n, k):
-    """
-    Solves the problem for given parameters n and k.
-    
-    Args:
-        n: The size parameter
-        k: The coefficient parameter
-    
-    Returns:
-        The result of the computation
-    """
-    # Initialize result variable
-    result = 0
-    
-    # Iterate through the range
-    for i in range(n):
-        result += i * k
-    
-    return result
 ```
 
-## Usage Example:
+2. 写求解函数：
 
 ```python
-# Call the solution function
-answer = solve(10, 2)
-print(answer)  # Output the result
-```
-
-## Key Points:
-
-- **Function signature**: Define the function with appropriate parameters
-- **Input validation**: Verify that inputs meet requirements
-- **Algorithm implementation**: Write the core logic to solve the problem
-- **Return value**: Ensure the function returns the correct result
-- **Documentation**: Include docstrings explaining the function's purpose```python
 def solve_carry_things(image: np.ndarray, prompt: str, **kw) -> SolverResult:
-    # ... CLIP / OpenCV / your method
+    # ... CLIP / OpenCV / 你的方法
     return SolverResult(
         action="click",
         candidate_click_sets=[
@@ -302,53 +324,42 @@ def solve_carry_things(image: np.ndarray, prompt: str, **kw) -> SolverResult:
         ],
         ...
     )
-```# 3. Add a branch in the dispatcher of `solve_bridge()`
+```
+
+3. 在 `solve_bridge()` 的 dispatcher 加分支：
 
 ```python
-def solve_bridge():
-    """
-    Solve the bridge puzzle
-    """
-    # dispatcher logic
-    if condition_a:
-        handle_case_a()
-    elif condition_b:
-        handle_case_b()
-    # Add new branch here
-    elif condition_c:
-        handle_case_c()
-``````python
 elif is_carry_things_prompt(prompt):
     result = solve_carry_things(image, prompt, ...)
-```# PR Welcome
+```
 
-Please see [CONTRIBUTING.md](../CONTRIBUTING.md).
-
----
-
-## Known Problem Type Coverage
-
-Currently covers approximately 12 common hCaptcha problem types (see table above). When encountering an unfamiliar prompt:
-
-- VLM enabled: Still attempts to output coordinates / candidate box decision directly from VLM
-- VLM fails: Throws `unknown_prompt` error
-- Debug information saved to `out_dir` for subsequent analysis
-
-Adding each new problem type typically requires:
-
-- 100–500 screenshots of that problem type (accumulated from `round_XX.png` generated by past daemon runs)
-- Reading prompt text to find patterns
-- Writing matching function + solver
-- Integration testing
+PR 欢迎，看 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 
 ---
 
-## Performance Tuning Recommendations
+## 已知题型覆盖范围
 
-| Scenario | Recommendation |
+当前覆盖约 12 种常见 hCaptcha 题型（看上面表格）。遇到没见过的 prompt 时：
+
+- VLM 启用：仍尝试 VLM 直出坐标 / 候选框决策
+- VLM 失败：抛 `unknown_prompt` 错误
+- 调试信息保存到 `out_dir` 供后续分析
+
+每加一种新题型大概需要：
+
+- 100–500 张该题型截图（用过去 daemon 跑出来的 `round_XX.png` 攒）
+- 读 prompt 文本找模式
+- 写匹配函数 + solver
+- 集成测试
+
+---
+
+## 性能调优建议
+
+| 场景 | 建议 |
 |---|---|
-| **VLM slow** | Reduce `vlm.timeout_s`, degrade early to heuristics |
-| **VLM inaccurate** | Switch to stronger model (`gpt-4o` → `claude-opus-4-7`), or modify system prompt |
-| **CLIP slow** | Use GPU venv (`pip install torch --index-url https://download.pytorch.org/whl/cu121`) |
-| **Too many retries** | Reduce `max_click_retries` / `max_drag_retries`, let daemon re-run instead of retrying within solver |
-| **Problem type not covered** | Add new solver (see above) |
+| **VLM 慢** | 调小 `vlm.timeout_s`，提前降级到启发式 |
+| **VLM 不准** | 换更强的模型（`gpt-4o` → `claude-opus-4-7`），或者改 system prompt |
+| **CLIP 慢** | 用 GPU venv（`pip install torch --index-url https://download.pytorch.org/whl/cu121`） |
+| **重试太多** | 调小 `max_click_retries` / `max_drag_retries`，让 daemon 重跑而不是 solver 内 retry |
+| **题型未覆盖** | 加新 solver（看上面） |

--- a/docs/images/README.md
+++ b/docs/images/README.md
@@ -1,64 +1,80 @@
-# Icon Assets
+# 图标资产
 
-[← Back to README](../../README.md)
+[← 回到 README](../../README.md)
 
-## File Inventory
+## 文件清单
 
-| File | Purpose | Size |
+| 文件 | 用途 | 尺寸 |
 |---|---|---|
-| `logo-light.svg` | Logo for light backgrounds (README light mode) | viewBox 256×256 |
-| `logo-dark.svg` | Logo for dark backgrounds (README dark mode) | viewBox 256×256 |
-| `icon.svg` | Generic icon that adapts to parent via `currentColor` | viewBox 64×64 |
-| `social-preview.svg` | GitHub repository social preview image | 1280×640 |
+| `logo-light.svg` | 浅色背景下的 logo（README light mode）| viewBox 256×256 |
+| `logo-dark.svg` | 深色背景下的 logo（README dark mode）| viewBox 256×256 |
+| `icon.svg` | 通用图标，用 `currentColor` 自适应父级 | viewBox 64×64 |
+| `social-preview.svg` | GitHub 仓库 Social preview 图 | 1280×640 |
 
-## Design Meaning
+## 设计含义
 
-Each element corresponds to the project core:```
+每个元素都对应项目核心：
+
+```
    ╭──────────╮
-   │  ▒    ·  │   ← outer circle = solver field of view / protocol scope
+   │  ▒    ·  │   ← 外圆 = solver 视场 / 协议作用域
    │   │    │ │
-   │   │  ▒ │ │   ← diagonal tiles highlighted = hCaptcha solver target locked
-   │ → │ ── │ │   ← horizontal arrow → = protocol replay traversal
-   │   │    │ │   ← vertical │ = protocol stack layering (client / server)
+   │   │  ▒ │ │   ← 对角两 tile 高亮 = hCaptcha solver 锁定的目标
+   │ → │ ── │ │   ← 横穿箭头 → = 协议重放穿越
+   │   │    │ │   ← 竖直 │ = 协议栈分层（client / server）
    ╰──────────╯
-```- Monochrome, no decoration, geometric
-- Recognizable at 16×16 favicon size
-- No copying of any commercial brands
+```
 
-## Using in README (add after making the repository public)
+- 单色，无装饰，几何
+- 在 16×16 favicon 尺寸下也能识别
+- 没有抄袭任何商业品牌
 
-> ⚠️ **GitHub cannot correctly render relative SVG paths in private repositories.** The browser receives GitHub blob view HTML instead of the SVG, which displays as strange page elements (like your own GitHub avatar). After switching the repository to public, the raw URL directly hits the SVG and this problem disappears. **So please add the reference snippet below to the main README only after making it public.**
+## 在 README 中使用（仓库 public 之后再加）
 
-After switching to public, place the logo centered at the top of the README (recommended):```html
+> ⚠️ **私有仓库下 GitHub 不能正确渲染相对路径的 SVG。** 浏览器拿到的不是 SVG 而是 GitHub blob 视图 HTML，会显示成奇怪的页面元素（比如你自己的 GitHub 头像）。仓库切 public 之后 raw URL 直接命中 SVG，这个问题就消失了。**所以下面的引用片段请等切 public 之后再加到主 README。**
+
+切到 public 后，logo 居中放在 README 顶部（推荐）：
+
+```html
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/images/logo-dark.svg">
     <img src="docs/images/logo-light.svg" width="160" alt="Gpt-Agreement-Payment">
   </picture>
 </p>
-```# Or the fragment hack writing method recommended by GitHub officials (dual images automatically switch themes, does not depend on picture):```html
+```
+
+或者 GitHub 官方推荐的 fragment hack 写法（双图自动切主题，不依赖 picture）：
+
+```html
 <p align="center">
   <img src="docs/images/logo-light.svg#gh-light-mode-only" width="160" alt="Gpt-Agreement-Payment">
   <img src="docs/images/logo-dark.svg#gh-dark-mode-only" width="160" alt="Gpt-Agreement-Payment">
 </p>
-```or small size inline next to the title (without disrupting the restrained feel of the research project):```html
+```
+
+或者标题旁内联小尺寸（不破坏研究项目克制感）：
+
+```html
 <h1>
   <img src="docs/images/icon.svg" width="32" valign="middle"> Gpt-Agreement-Payment
 </h1>
-```## Setting Up GitHub Social Preview
+```
 
-1. Open `social-preview.svg` in a browser, take a screenshot or export as PNG (you can also use `librsvg`:
+## 设置 GitHub Social preview
+
+1. 在浏览器打开 `social-preview.svg`，截图或导出 PNG（也可以用 `librsvg`：
    ```bash
    rsvg-convert -w 1280 -h 640 docs/images/social-preview.svg -o /tmp/social.png
    ```
-2. GitHub repository → Settings → General → Social preview → Upload an image
-3. After uploading, all link previews shared from Twitter / Slack / RSS and other platforms will use this image
+2. GitHub 仓库 → Settings → General → Social preview → Upload an image
+3. 上传后所有从 Twitter / Slack / RSS 等地方分享出去的链接预览都用这张图
 
-## Modifications and Recreation
+## 修改与重制
 
-SVG is a text format and can be edited directly with any editor. After making changes:
+SVG 是文本格式，可以直接用任何编辑器改。改完之后：
 
-- Keep it monochrome (don't add gradients / filters, may render inconsistently across browsers)
-- Maintain the viewBox aspect ratio (don't change to a rectangle, will break geometric symmetry)
-- When changing colors, use `#1f2328` (GitHub neutral dark gray) for light version and `#e6edf3` (light gray) for dark version—both colors look natural under both GitHub themes
-- If adding text, use `font-family="ui-monospace, monospace"` to maintain consistency with the project style
+- 保持单色（不要加渐变 / 滤镜，可能在不同浏览器渲染不一致）
+- 保持 viewBox 比例（不要改成长方形，会破坏几何对称）
+- 改色时 light 版用 `#1f2328`（GitHub 中性深灰），dark 版用 `#e6edf3`（亮灰），这两个色在两种 GitHub theme 下都自然
+- 如果加文字，用 `font-family="ui-monospace, monospace"` 跟项目调性一致

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,19 +1,21 @@
-# Installation Guide
+# 安装指南
 
-[← Back to README](../README.md)
+[← 回到 README](../README.md)
 
-## System Requirements
+## 系统要求
 
-- **OS**: Linux (Ubuntu 22.04+ / Debian 11+ / Kali / any systemd distribution)
-- **Python**: 3.11+
-- **Memory**: At least 2 GB (hCaptcha solver + Camoufox running simultaneously)
-- **Disk**: Core ~500 MB, plus 5 GB total with ML venv
-- **Network**: Access to OpenAI / Stripe / PayPal / Cloudflare API
-- **Optional**: xvfb (for headless execution), gost (for socks5 with auth)
+- **OS**：Linux（Ubuntu 22.04+ / Debian 11+ / Kali / 任何 systemd 发行版）
+- **Python**：3.11+
+- **内存**：至少 2 GB（hCaptcha solver + Camoufox 同时跑）
+- **磁盘**：核心约 500 MB，加上 ML venv 总共 5 GB
+- **网络**：能访问 OpenAI / Stripe / PayPal / Cloudflare API
+- **可选**：xvfb（跑无头时用）、gost（带 auth 的 socks5 用）
 
 ---
 
-## Step 1: System Packages```bash
+## 第一步：系统包
+
+```bash
 # Kali / Debian / Ubuntu
 sudo apt update && sudo apt install -y \
     python3 python3-pip python3-venv \
@@ -21,125 +23,177 @@ sudo apt update && sudo apt install -y \
     curl wget git \
     sqlite3 jq
 
-# Install gost (SOCKS5-with-auth → SOCKS5-no-auth relay, Camoufox doesn't support socks5 auth)
+# 装 gost（SOCKS5-with-auth → SOCKS5-no-auth 中继，Camoufox 不吃 socks5 auth）
 sudo curl -sSfL \
     https://github.com/go-gost/gost/releases/latest/download/gost-linux-amd64 \
     -o /usr/local/bin/gost && sudo chmod +x /usr/local/bin/gost
-```---
+```
 
-## Step 2: Core Python Dependencies```bash
+---
+
+## 第二步：核心 Python 依赖
+
+```bash
 git clone https://github.com/DanOps-1/Gpt-Agreement-Payment
 cd Gpt-Agreement-Payment
 
 pip install requests curl_cffi playwright camoufox browserforge mitmproxy pybase64
 
-# Playwright + Camoufox browser binary
+# Playwright + Camoufox 浏览器二进制
 playwright install firefox
 camoufox fetch
-```## Step 3: Optional ML venv (hCaptcha Visual Solver)
+```
 
-The ML dependencies for the solver are quite heavy, so it's recommended to install them in a separate venv:```bash
+---
+
+## 第三步：可选 ML venv（hCaptcha 视觉求解器）
+
+solver 的 ML 依赖比较重，建议单独装到独立 venv：
+
+```bash
 python -m venv ~/.venvs/ctfml
 ~/.venvs/ctfml/bin/pip install \
     torch transformers \
     opencv-python pillow numpy
-```It can run without installation, it's just that the solver will skip heuristic fallback and rely entirely on VLM. For VLM endpoint configuration, see [`configuration.md`](configuration.md#vlm-endpoint).
+```
+
+不装也能跑，只是 solver 会跳过启发式回退，全靠 VLM。VLM endpoint 配置看 [`configuration.md`](configuration.md#vlm-endpoint)。
 
 ---
 
-## Step 4: Copy Template Configuration```bash
+## 第四步：拷模板配置
+
+```bash
 cp CTF-pay/config.paypal.example.json       CTF-pay/config.paypal.json
 cp CTF-reg/config.paypal-proxy.example.json CTF-reg/config.paypal-proxy.json
 cp CTF-reg/config.example.json              CTF-reg/config.noproxy.json
-```See [`configuration.md`](configuration.md) for the meaning of each field.
+```
+
+每个字段含义看 [`configuration.md`](configuration.md)。
 
 ---
 
-## Step 5: CF API Token (for creating new subdomains)
+## 第五步：CF API token（开新子域用）
 
-If you want to use multiple zone domain pools with automatic catch-all subdomain creation, you need a Cloudflare API token:
+如果要走多 zone 域池自动开 catch-all 子域，需要 Cloudflare API token：
 
-1. Log in to [https://dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
+1. 登 [https://dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
 2. **Create Token** → **Custom token**
-3. Permissions:
+3. 权限：
    - `Zone` → `DNS` → `Edit`
    - `Zone` → `Zone` → `Read`
-4. Select the zones you want to manage in Zone Resources
-5. After creation, write it to `SQLite runtime_meta[secrets]`:```json
+4. Zone Resources 选你要管的 zone
+5. 创建后写到 `SQLite runtime_meta[secrets]`：
+
+```json
 {
   "cloudflare": {
-    "api_token": "your token",
+    "api_token": "你的 token",
     "forward_to": "admin@example.com"
   }
 }
-````output/` directory is already in gitignore and won't be committed.
+```
+
+`output/` 目录已经被 gitignore，不会进 commit。
 
 ---
 
-## Step 6: First Run of PayPal
+## 第六步：第一次跑 PayPal
 
-The first run will launch Camoufox and prompt you to log in to PayPal. This step **requires manual handling of OTP 2FA at least once**:```bash
+第一次跑会弹 Camoufox 让你登 PayPal。这一步**必须人肉过一次** OTP 2FA：
+
+```bash
 xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal
-```> ⚠️ **If using a remote server**: Use VNC / X11 forwarding or temporarily disable `xvfb-run` to display directly. Alternatively, copy the entire `paypal_cf_persist/` directory from a machine that has already logged into PayPal.
+```
 
-After successful login, cookies are persisted to `CTF-pay/paypal_cf_persist/` (gitignored), and subsequent runs will reuse the trusted device state.
+> ⚠️ **如果是远程服务器**：用 VNC / X11 forwarding 或者临时取消 `xvfb-run` 直接显示。或者把 `paypal_cf_persist/` 整个目录从已经登过 PayPal 的机器拷过来。
 
-> ⚠️ **You must disable push notifications on PayPal's backend** (Settings → Login management → Remove mobile device), otherwise it will prioritize sending push notifications instead of email OTP, and automation will get stuck.
+登成功后 cookies 持久化到 `CTF-pay/paypal_cf_persist/`（gitignored），后面跑都复用受信任设备状态。
+
+> ⚠️ **PayPal 一定要在它后台关掉手机推送**（Settings → Login management → 移除手机设备），否则它会优先发推送而不是邮箱 OTP，自动化会卡住。
 
 ---
 
-## Verifying Installation```bash
-# Check core packages
+## 验证安装
+
+```bash
+# 看核心包
 python -c "import camoufox, playwright, curl_cffi; print('core ok')"
 
-# Check ML venv
+# 看 ML venv
 ~/.venvs/ctfml/bin/python -c "import torch, transformers, cv2; print('ml ok')"
 
-# Check gost
+# 看 gost
 gost -V
 
-# Check xvfb
+# 看 xvfb
 which xvfb-run
-```All four returning OK means you're ready to go.
+```
+
+四条都返 OK 就可以开跑了。
 
 ---
 
-## Common Installation Issues
+## 常见安装问题
 
-### `camoufox fetch` hangs or download fails
+### `camoufox fetch` 卡住或下载失败
 
-Domestic networks have slow GitHub release downloads, you can add a proxy:```bash
+国内网络拉 GitHub release 慢，可以加代理：
+
+```bash
 HTTPS_PROXY=http://127.0.0.1:7890 camoufox fetch
-```Or manually download from [https://github.com/daijro/camoufox/releases](https://github.com/daijro/camoufox/releases) and place it in `~/.cache/camoufox/`.
+```
 
-### `playwright install firefox` fails```bash
-# Use domestic mirror
+或者手动从 [https://github.com/daijro/camoufox/releases](https://github.com/daijro/camoufox/releases) 下载放到 `~/.cache/camoufox/`。
+
+### `playwright install firefox` 失败
+
+```bash
+# 用国内镜像
 PLAYWRIGHT_DOWNLOAD_HOST=https://npmmirror.com/mirrors/playwright \
     playwright install firefox
-```### Torch Installation is Slow / Won't Install```bash
-# CPU only version (much smaller)
+```
+
+### Torch 安装慢 / 装不上
+
+```bash
+# CPU only 版本（小很多）
 ~/.venvs/ctfml/bin/pip install torch --index-url https://download.pytorch.org/whl/cpu
-```# If your machine has a GPU and wants to use CUDA:```bash
+```
+
+如果你的机器有 GPU 想用 CUDA：
+
+```bash
 ~/.venvs/ctfml/bin/pip install torch --index-url https://download.pytorch.org/whl/cu121
-```### Camoufox Reports `socks5 auth not supported`
+```
 
-This is expected behavior. Configure a gost relay:```bash
+### Camoufox 报 `socks5 auth not supported`
+
+这是预期行为，配 gost 中继：
+
+```bash
 gost -L=socks5://:18898 -F=socks5://USER:PASS@PROXY_HOST:PORT &
-```Then in config, point the proxy to `socks5://127.0.0.1:18898`. Daemon mode has a built-in gost watchdog that will automatically manage this process.
+```
 
-### Getting `cannot open display` error when running
+然后在 config 里把 proxy 指向 `socks5://127.0.0.1:18898`。daemon 模式有内置 gost 看门狗，会自动管理这个进程。
 
-xvfb is not running or the environment variable is not set:```bash
-# Wrap with xvfb-run (recommended)
+### 跑起来报 `cannot open display`
+
+xvfb 没跑或者环境变量没传：
+
+```bash
+# 用 xvfb-run 包一层（推荐）
 xvfb-run -a python pipeline.py ...
 
-# Or manually start Xvfb
+# 或者手动起 Xvfb
 Xvfb :99 -screen 0 1920x1080x24 &
 DISPLAY=:99 python pipeline.py ...
-```---
+```
 
-## Next Steps
+---
 
-- Configuration Details → [`configuration.md`](configuration.md)
-- Getting Started → [`operating-modes.md`](operating-modes.md)
-- Troubleshooting → [`debugging.md`](debugging.md)
+## 下一步
+
+- 配置详解 → [`configuration.md`](configuration.md)
+- 跑起来 → [`operating-modes.md`](operating-modes.md)
+- 排错 → [`debugging.md`](debugging.md)

--- a/docs/operating-modes.md
+++ b/docs/operating-modes.md
@@ -1,161 +1,195 @@
-# Running Modes
+# 运行模式
 
-[← Back to README](../README.md)
+[← 回到 README](../README.md)
 
-All four modes use the same `pipeline.py` entry point and switch between them via command-line parameters.
+四种模式都用同一个 `pipeline.py` 入口，靠命令行参数切换。
 
 ---
 
-## Single Run```bash
+## 单次
+
+```bash
 xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal
-```Register → Pay → OAuth → Write SQLite runtime library (`output/webui.db`). About five minutes overall.
+```
 
-The most commonly used mode during debugging. Run through the complete pipeline each time to see where it fails.
+注册 → 支付 → OAuth → 写 SQLite 运行时库（`output/webui.db`）。整体五分钟左右。
+
+调试时最常用的模式。每次跑一遍完整链路看哪里挂。
 
 ---
 
-## Batch Parallel```bash
+## 批量并行
+
+```bash
 xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal \
     --batch 10 --workers 3
-```| Parameter | Meaning |
-|---|---|
-| `--batch N` | Run N complete pipelines |
-| `--workers M` | Parallelize M workers |
+```
 
-> ⚠️ **Parallelization is not free**. Multiple account registrations within the same time window trigger batch association, which from an anti-fraud perspective is treated as a cohort. It's recommended to keep `--workers` no more than 3, and have each worker use different proxies / domains / time jitter. See [`anti-fraud-research.md`](anti-fraud-research.md) for details.
+| 参数 | 含义 |
+|---|---|
+| `--batch N` | 跑 N 个完整 pipeline |
+| `--workers M` | 并行 M 个 worker |
+
+> ⚠️ **并行不是免费的**。同一时间窗口内多个号注册会触发批次关联，反欺诈层面看就是一个 cohort。建议 `--workers` 不超过 3，且每个 worker 用不同的代理 / 域 / 时间抖动。详见 [`anti-fraud-research.md`](anti-fraud-research.md)。
 
 ---
 
-## Self-dealer
+## 自产自销（self-dealer）
 
-The most cost-effective approach. One PayPal charge gets you a complete Team workspace with 1 owner + N members. Each member is an independent ChatGPT account with a separate OAuth `refresh_token`.```bash
-# 1 owner + 4 members
+最省钱的玩法。一次 PayPal 扣款换来 1 owner + N member 的完整 Team workspace。每个 member 都是独立 ChatGPT 账号，可以单独换 OAuth `refresh_token`。
+
+```bash
+# 1 owner + 4 member
 xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal --self-dealer 4
 
-# Reuse paid owner, skip Step 1 to save one charge
+# 复用已付费 owner，跳过 Step 1 省一次扣款
 xvfb-run -a python pipeline.py --config CTF-pay/config.paypal.json --paypal \
     --self-dealer 4 --self-dealer-resume <owner_email>
-```### Internal Timeline
+```
 
-| Stage | Count | Reuse | Output |
+### 内部时序
+
+| 阶段 | 次数 | 复用 | 产出 |
 |---|---|---|---|
-| 1. Register → Payment → Push Downstream | 1 (owner) | `pipeline()` / `card.py` | `team_id` + owner refresh_token |
-| 2. Register → Invite → Accept Invite → Push Downstream | N (member) | `register()` + invites API + `_exchange_refresh_token_with_session` | N member refresh_tokens, all bound to same `team_id` |
+| 1. 注册 → 支付 → 推下游 | 1 (owner) | `pipeline()` / `card.py` | `team_id` + owner refresh_token |
+| 2. 注册 → 邀请 → 接受邀请 → 推下游 | N (member) | `register()` + invites API + `_exchange_refresh_token_with_session` | N 个 member refresh_token，全绑同一 `team_id` |
 
-### Member Loop Single Iteration Timeline (~3 minutes steady state)
+### Member 循环单次时序（约 3 分钟稳态）
 
-1. Pick proxy + pick subdomain + write temp `cardw` config (consistent with owner pipeline)
-2. `register()` —— Camoufox passes Turnstile + fetch OTP from CF KV (≈ 1 minute)
-3. Owner's Bearer calls `POST /backend-api/accounts/{team_id}/invites` (< 1 second)
-4. Member's Bearer calls `POST /backend-api/accounts/{team_id}/invites/accept` (< 1 second)
-5. `card._exchange_refresh_token_with_session` —— Camoufox re-login (email + password + consent) to get refresh_token (~30 seconds)
-6. Append records per SQLite runtime → push downstream
+1. 挑代理 + 挑子域 + 写临时 `cardw` 配置（跟单 owner pipeline 一致）
+2. `register()` —— Camoufox 过 Turnstile + CF KV 取 OTP（≈ 1 分钟）
+3. owner 的 Bearer 调 `POST /backend-api/accounts/{team_id}/invites`（< 1 秒）
+4. member 的 Bearer 调 `POST /backend-api/accounts/{team_id}/invites/accept`（< 1 秒）
+5. `card._exchange_refresh_token_with_session` —— Camoufox 重登（email + password + consent）拿 refresh_token（约 30 秒）
+6. 按 SQLite runtime 追加记录 → 推下游
 
-### Key APIs (reverse-engineered from chatgpt.com frontend JS)```
+### 关键 API（从 chatgpt.com 前端 JS 逆出来的）
+
+```
 POST https://chatgpt.com/backend-api/accounts/{team_id}/invites
-   ↓ owner Bearer, body: {emails: ["target@..."]}
+   ↓ owner Bearer，body: {emails: ["target@..."]}
 
 POST https://chatgpt.com/backend-api/accounts/{team_id}/invites/accept
-   ↓ invitee Bearer, frontend JS `4813494d-*.js` contains /accounts/{account_id}/invites/accept
-```### Security Mechanism (Reuse owner pipeline)
+   ↓ invitee Bearer，前端 JS `4813494d-*.js` 里 /accounts/{account_id}/invites/accept
+```
 
-- Each member independently picks `proxy_pool.pick()` + `domain_pool.pick()` + temporary cardw config, no association
-- Any single member failure at any step (registration / invitation / acceptance / re-login / CPA) is caught by try/except, continue to next one
-- `--self-dealer-resume` reads existing owners (already paid) from SQLite with `team_account_id` + `refresh_token`, avoiding duplicate charges
+### 安全机制（复用 owner pipeline）
 
-### Two Codex OAuth calls per member (first one must fail)
+- 每个 member 单独挑 `proxy_pool.pick()` + `domain_pool.pick()` + 临时 cardw 配置，不关联
+- 任何单个 member 任何一步失败（注册 / 邀请 / 接受 / 重登 / CPA）都被 try/except 捕获，继续下一个
+- `--self-dealer-resume` 读 SQLite 里既有 owner（已付费）的 `team_account_id` + `refresh_token`，避免重复扣款
 
-- **First call**: signup state hydra session at the end of registration flow in `browser_register.py`. **Must fail** (`token_exchange_user_error`). Default `SKIP_SIGNUP_CODEX_RT=1` to skip; set to `0` to see old path
-- **Second call**: Camoufox re-login (login state full user session) —— successfully obtain RT
+### 每个 member 两次 Codex OAuth（第一次必失败）
+
+- **第一次**：`browser_register.py` 注册流程末尾的 signup 态 hydra session。**必失败**（`token_exchange_user_error`）。默认 `SKIP_SIGNUP_CODEX_RT=1` 跳过；想看旧路径设 `0`
+- **第二次**：Camoufox 重登（login 态 full user session）—— 成功拿 RT
 
 ---
 
-## Daemon Mode —— Continuously maintain recovery account pool
+## Daemon 模式 —— 持续维护补号池
 
-Allow pipeline to run as a resident background service, automatically maintaining the number of available accounts in external [gpt-team](https://github.com/DanOps-1/gpt-team) **recovery account pool** (`account_usage='recovery'`) to always be ≥ target value.```bash
-# Run in background (recommended, -u disables buffering for real-time log writes)
+让 pipeline 作为常驻后台服务，自动维护外部 [gpt-team](https://github.com/DanOps-1/gpt-team) **补号池**（`account_usage='recovery'`）的可用账号数始终 ≥ 目标值。
+
+```bash
+# 后台跑（推荐，-u 关 buffer 让日志实时写）
 (nohup xvfb-run -a python3 -u pipeline.py --config CTF-pay/config.paypal.json --paypal --daemon \
     > output/logs/daemon-$(date +%Y%m%d-%H%M%S).log 2>&1 &)
 
-# Tail logs
+# 跟日志
 tail -f output/logs/daemon-*.log
 
-# Run in foreground (for debugging, graceful exit with Ctrl+C)
+# 前台跑（调试用，Ctrl+C 优雅退出）
 xvfb-run -a python3 -u pipeline.py --config CTF-pay/config.paypal.json --paypal --daemon
 
-# Check status
+# 看状态
 cat SQLite runtime_meta[daemon_state] | jq .
 
-# Graceful stop (finishes current cycle before exiting)
+# 优雅停（跑完当前周期再退）
 pkill -TERM -f "pipeline.*--daemon"
 
-# Force kill (cleans up Camoufox + Xvfb remnants together)
+# 强杀（连 Camoufox + Xvfb 残留一起清）
 pkill -9 -f "pipeline.*--daemon"
 pkill -9 -f camoufox-bin
 pkill -9 -f browser_register
 for pid in $(pgrep Xvfb); do kill -9 $pid; done
-```# Work Loop```
+```
+
+### 工作循环
+
+```
 loop:
     sleep poll_interval_s
 
-    if rate_limit stuck:
+    if rate_limit 卡了:
         continue
 
-    usable = check gpt-team DB (!isBanned && !isDisabled && !noInvitePermission && !expired && seat not full)
+    usable = 查 gpt-team DB（!isBanned && !isDisabled && !noInvitePermission && !expired && seat 未满）
 
     if usable < target_ok_accounts:
         try:
-            ensure_gost_alive()       # watchdog
-            cleanup_temp_leftovers()  # /tmp orphans
-            if should cleanup CF:
+            ensure_gost_alive()       # 看门狗
+            cleanup_temp_leftovers()  # /tmp 孤儿
+            if 该清 CF 了:
                 cleanup_dead_cf()
             run_pipeline()
-            clear state machine flags (if invite=ok)
+            清状态机标志（如果 invite=ok）
         except:
-            route to corresponding self-healing branch by exception type
-```### 12-Path Self-Healing Loop
+            按异常类型走对应自愈分支
+```
 
-See [`daemon-mode.md`](daemon-mode.md) for details.
+### 12 路自愈环
+
+详见 [`daemon-mode.md`](daemon-mode.md)。
 
 ---
 
-## Registration Only / Payment Only
+## 仅注册 / 仅支付
 
-For debugging: run the process in separate steps:```bash
-# Register only
+调试用：把流程拆开跑：
+
+```bash
+# 只注册
 python pipeline.py --register-only --cardw-config CTF-reg/config.paypal-proxy.json
 
-# Pay only (using the latest account in SQLite)
+# 仅支付（用 SQLite 里最新账号）
 xvfb-run -a python pipeline.py --pay-only --config CTF-pay/config.paypal.json --paypal
-```## Directly Call card.py
+```
 
-Skip the pipeline orchestrator and directly call card.py:```bash
-# Standard card payment (auto_register mode)
+---
+
+## 直接调 card.py
+
+跳过 pipeline 编排器，直接调 card.py：
+
+```bash
+# 标准卡支付（auto_register 模式）
 python CTF-pay/card.py auto --config CTF-pay/config.auto.json
 
-# Continue from existing checkout session
+# 从已有 checkout session 续跑
 python CTF-pay/card.py cs_live_xxx --config CTF-pay/config.auto.json
 
-# Use the Nth card (0-based)
+# 用第 N 张卡（0-based）
 python CTF-pay/card.py auto --card 1 --config CTF-pay/config.auto.json
 
-# Offline replay (no external requests)
+# 离线回放（不发外部请求）
 python CTF-pay/card.py auto --config CTF-pay/config.offline-replay.json --offline-replay
 
-# Local mock gateway
+# 本地 mock gateway
 python CTF-pay/card.py auto --config CTF-pay/config.local-mock.json --local-mock
 
-# Repeatedly test decline card terminal state
+# 重复刷拒卡终态
 python CTF-pay/retry_house_decline.py cs_live_xxx --attempts 5
-```---
+```
 
-## Measured Time Optimization Switches
+---
 
-Based on recent comprehensive daemon + self-dealer logs, two paths with 100% failure rates now have switches that skip them by default:
+## 实测耗时优化开关
 
-| Environment Variable | Default | Savings | Description |
+基于近期 daemon + self-dealer 全量日志，两条 100% 失败的路径已加开关默认跳过：
+
+| 环境变量 | 默认 | 节省 | 说明 |
 |---|---|---|---|
-| `SKIP_SIGNUP_CODEX_RT` | `1` | ~30s/registration | signup state hydra session cannot exchange for Codex RT (`token_exchange_user_error`), refresh_token is obtained later via `_exchange_refresh_token_with_session` (pay / self-dealer re-login) |
-| `SKIP_HERMES_FAST_PATH` | `1` | 5–10s/payment | PayPal returns `/checkoutweb/genericError?code=REVGQVVMVA` ("DEFAULT") for non-browser cookied sessions, all payments actually use the browser path |
+| `SKIP_SIGNUP_CODEX_RT` | `1` | ~30s/注册 | signup 态 hydra session 无法换 Codex RT（`token_exchange_user_error`），refresh_token 由后续 `_exchange_refresh_token_with_session`（pay / self-dealer 重登）拿 |
+| `SKIP_HERMES_FAST_PATH` | `1` | 5–10s/支付 | PayPal 对非浏览器 cookied session 返 `/checkoutweb/genericError?code=REVGQVVMVA`（"DEFAULT"），所有支付实际都走浏览器路径 |
 
-Both switches are enabled by default (skipping guaranteed failure paths). Set `SKIP_*=0` to restore the old behavior if you want to compare or when PayPal changes the protocol.
+两个开关默认开启（跳过必失败路径），想对比或 PayPal 改协议时可设 `SKIP_*=0` 恢复旧行为。

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,38 +1,42 @@
-# webui — Configuration Wizard + Preflight Health Check
+# webui — 配置向导 + preflight 体检
 
-Compress the 1-3 hours configuration process to run `pipeline.py` successfully down to ~15 minutes.
+把 `pipeline.py` 第一次跑通的 1-3 小时配置过程压到 ~15 分钟。
 
-## Quick Start```bash
-# Backend dependencies
+## 快速开始
+
+```bash
+# 后端依赖
 pip install -r webui/requirements.txt
 
-# Frontend build (one time)
+# 前端构建（一次）
 cd webui/frontend && pnpm i && pnpm build && cd ../..
 
-# Start
+# 启动
 python -m webui.server
-# Open in browser http://127.0.0.1:8765
-```# First-Time Access
+# 浏览器开 http://127.0.0.1:8765
+```
 
-First-time access will redirect to `/setup` to create an admin account.
+首次访问会跳到 `/setup` 创建管理员账号。
 
-## 14-Step Process
+## 14 步流程
 
-See `docs/superpowers/specs/2026-04-28-webui-design.md` for details.
+详见 `docs/superpowers/specs/2026-04-28-webui-design.md`。
 
-| Phase | Steps |
+| Phase | 步骤 |
 |---|---|
-| 1 Basics (5) | Mode selection / System dependencies / Cloudflare / IMAP / Proxy |
-| 2 Payment (2) | PayPal / Card + Billing |
-| 3 CAPTCHA (2, optional) | CAPTCHA solving service / VLM endpoint |
-| 4 Downstream (4) | Team plan / gpt-team / CPA / Daemon / Stripe runtime |
-| 5 Completion (1) | Review + Export |
+| 1 基础（5）| 模式选择 / 系统依赖 / Cloudflare / IMAP / 代理 |
+| 2 支付（2）| PayPal / 卡 + Billing |
+| 3 验证码（2，可选）| 打码平台 / VLM endpoint |
+| 4 下游（4）| Team plan / gpt-team / CPA / Daemon / Stripe runtime |
+| 5 完成（1）| Review + 导出 |
 
-The right column `PreflightPanel` displays passed checks in real-time for each step.
+每步右栏 `PreflightPanel` 实时显示已通过的 check。
 
-## Reverse Proxy (Public Internet Access)
+## 反向代理（公网访问）
 
-The webui binds to `127.0.0.1` by default. To allow access from other machines, use nginx reverse proxy:```nginx
+webui 默认 bind `127.0.0.1`。要让其他机器访问，nginx 反代：
+
+```nginx
 location /webui/ {
     proxy_pass http://127.0.0.1:8765/;
     proxy_http_version 1.1;
@@ -41,20 +45,26 @@ location /webui/ {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
 }
-```## Development```bash
-# Backend development mode (auto-reload)
+```
+
+## 开发
+
+```bash
+# 后端开发模式（auto-reload）
 uvicorn webui.server:create_app --factory --reload --host 127.0.0.1 --port 8765
 
-# Frontend development mode (Vite proxy auto-transforms /api → 8765)
+# 前端开发模式（Vite proxy 自动转 /api → 8765）
 cd webui/frontend && pnpm dev
-# Open http://127.0.0.1:5173
+# 开 http://127.0.0.1:5173
 
-# Run tests
-python -m pytest webui/tests/ -v       # Backend 47 tests
-cd webui/frontend && pnpm test         # Frontend Vitest
-```## Architecture
+# 跑测试
+python -m pytest webui/tests/ -v       # 后端 47 测试
+cd webui/frontend && pnpm test         # 前端 Vitest
+```
 
-- Backend: FastAPI + SQLite (users + sessions) + JSON (wizard state) + bcrypt + sse-starlette
-- Frontend: Vue 3 + Vite + TypeScript + Naive UI + Pinia + Vue Router
-- Authentication: cookie session (httponly + SameSite=Lax)
-- Launch: single process `python -m webui.server`, FastAPI serves both API + static frontend simultaneously
+## 架构
+
+- 后端：FastAPI + SQLite (users + sessions) + JSON (wizard state) + bcrypt + sse-starlette
+- 前端：Vue 3 + Vite + TypeScript + Naive UI + Pinia + Vue Router
+- 鉴权：cookie session（httponly + SameSite=Lax）
+- 启动：单进程 `python -m webui.server`，FastAPI 同时 serve API + 静态前端


### PR DESCRIPTION
## What & why

PR #31 translated all docs to English but **mangled markdown code fences** — the closing ``` got glued onto the following heading / table / paragraph across **all 12 docs**. On GitHub the English code blocks never close, so prose gets swallowed into code blocks (the same fence-mishandling that broke the 2 docstrings, but markdown isn't compiled so CI didn't catch it). The Chinese originals were clean.

Per the chosen direction (**Chinese canonical + bilingual README only**):

- **README is bilingual**: `README.md` (Chinese, default) ⇄ `README.en.md` (English), with a language-switch link at the top of each. `README.en.md`'s fence structure was repaired and **verified against the Chinese block structure** (8 blocks: `mermaid` + `bash`×7 — lang sequence matches, fences balanced, 0 glued).
- **All other docs** (`docs/*.md`, `CONTRIBUTING`/`SECURITY`/`CODE_OF_CONDUCT`, `webui/` & `CTF-pay/` READMEs): **reverted to pristine Chinese** (clean rendering). Their broken English `.en.md` variants are dropped.

Code comments/docstrings stay English (from #31). The Chinese originals remain recoverable from git (`8b2243f`) for any doc, if a properly-formatted English translation is done later.

## Verification
- Every shipping `.md` has balanced fences; only `README.en.md` ships as English.
- The 14 reverted docs are byte-identical to the pristine `8b2243f` Chinese.